### PR TITLE
workflows: publish to crates.io on release

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,0 +1,14 @@
+name: publish-crate
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  crate:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: cargo publish
+      env:
+        CARGO_REGISTRY_TOKEN: ${{ secrets.LE_AUTOMATON_CRATES_IO_API_TOKEN }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,11 @@
 [package]
-name = "libprio-rs"
-version = "0.1.0"
+name = "prio"
+version = "0.1.1"
 authors = ["Josh Aas <jaas@kflag.net>", "Karl Tarbe <tarbe@apple.com>"]
 edition = "2018"
 description = "Implementation of the Prio aggregation system core: https://crypto.stanford.edu/prio/"
 license = "MPL-2.0"
+repository = "https://github.com/abetterinternet/libprio-rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,19 @@
 # libprio-rs
-[![Actions Status](https://github.com/abetterinternet/libprio_rs/workflows/ci-build/badge.svg)](https://github.com/abetterinternet/libprio_rs/workflows/ci-build/badge.svg)
+[![Build Status]][actions] [![Latest Version]][crates.io]
+
+[Build Status]: https://github.com/abetterinternet/libprio-rs/workflows/ci-build/badge.svg
+[actions]: https://github.com/abetterinternet/libprio-rs/actions?query=branch%3Amain
+[Latest Version]: https://img.shields.io/crates/v/prio.svg
+[crates.io]: https://crates.io/crates/prio
 
 Pure Rust implementation of [Prio](https://crypto.stanford.edu/prio/), a system for Private, Robust, and Scalable Computation of Aggregate Statistics.
+
+## Releases
+
+We use a GitHub Action to publish a crate named `prio` to [crates.io](https://crates.io). To cut a release and publish:
+
+- Bump the version number in `Cargo.toml` to e.g. `1.2.3` and merge that change to `main`
+- Tag that commit on main as `v1.2.3`, either in `git` or in [GitHub's releases UI](https://github.com/abetterinternet/libprio-rs/releases/new).
+- Publish a release in [GitHub's releases UI](https://github.com/abetterinternet/libprio-rs/releases/new).
+
+Publishing the release will automatically publish the updated `prio` crate to `crates.io`.

--- a/tests/accumulating.rs
+++ b/tests/accumulating.rs
@@ -1,10 +1,10 @@
 // Copyright (c) 2020 Apple Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-use libprio_rs::client::*;
-use libprio_rs::encrypt::*;
-use libprio_rs::finite_field::Field;
-use libprio_rs::server::*;
+use prio::client::*;
+use prio::encrypt::*;
+use prio::finite_field::Field;
+use prio::server::*;
 
 #[test]
 fn accumulation() {
@@ -62,6 +62,6 @@ fn accumulation() {
     let total1 = server1.total_shares();
     let total2 = server2.total_shares();
 
-    let reconstructed = libprio_rs::util::reconstruct_shares(total1, total2).unwrap();
+    let reconstructed = prio::util::reconstruct_shares(total1, total2).unwrap();
     assert_eq!(reconstructed, reference_count);
 }

--- a/tests/tweaks.rs
+++ b/tests/tweaks.rs
@@ -1,11 +1,11 @@
 // Copyright (c) 2020 Apple Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-use libprio_rs::client::*;
-use libprio_rs::encrypt::*;
-use libprio_rs::finite_field::Field;
-use libprio_rs::server::*;
-use libprio_rs::util::*;
+use prio::client::*;
+use prio::encrypt::*;
+use prio::finite_field::Field;
+use prio::server::*;
+use prio::util::*;
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum Tweak {


### PR DESCRIPTION
Adds a workflow triggered by the publishing of a GitHub release which
publishes a crate to crates.io. While the repo is named `libprio-rs`,
Rust naming conventions frown on both the prefix and the suffix: `lib`
is implied by it being a library crate and `-rs` is implied by it being
a Rust crate at all
(https://rust-lang.github.io/api-guidelines/naming.html,
https://doc.rust-lang.org/stable/rust-by-example/crates/lib.html).
Accordingly, the crate is simply named `prio`.

This also adds instructions to the README for cutting releases in GitHub
and also fixes the existing status icons.