### PR TITLE
Implement std::error::Error for EncryptError

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,9 @@ repository = "https://github.com/abetterinternet/libprio-rs"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rand = "0.7"
 aes-ctr = "0.4.0"
-base64 = "0.12.3"
-ring = "0.16.15"
 aes-gcm = "0.6.0"
+base64 = "0.12.3"
+rand = "0.7"
+ring = "0.16.15"
+thiserror = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prio"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Josh Aas <jaas@kflag.net>", "Karl Tarbe <tarbe@apple.com>"]
 edition = "2018"
 description = "Implementation of the Prio aggregation system core: https://crypto.stanford.edu/prio/"

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -17,17 +17,22 @@ pub const TAG_LENGTH: usize = 16;
 const KEY_LENGTH: usize = 16;
 
 /// Possible errors from encryption / decryption.
-#[derive(Debug)]
+#[derive(Debug, thiserror::Error)]
 pub enum EncryptError {
     /// Base64 decoding error
-    DecodeBase64Error(base64::DecodeError),
+    #[error("base64 decoding error")]
+    DecodeBase64Error(#[from] base64::DecodeError),
     /// Error in ECDH
+    #[error("error in ECDH")]
     KeyAgreementError,
     /// Buffer for ciphertext was not large enough
+    #[error("buffer for ciphertext was not large enough")]
     EncryptionError,
     /// Authentication tags did not match.
+    #[error("authentication tags did not match")]
     DecryptionError,
     /// Input ciphertext was too small
+    #[error("input ciphertext was too small")]
     DecryptionLengthError,
 }
 
@@ -44,7 +49,7 @@ pub struct PrivateKey(Vec<u8>);
 impl PublicKey {
     /// Load public key from a base64 encoded X9.62 uncompressed representation.
     pub fn from_base64(key: &str) -> Result<Self, EncryptError> {
-        let keydata = base64::decode(key).map_err(EncryptError::DecodeBase64Error)?;
+        let keydata = base64::decode(key)?;
         Ok(PublicKey(keydata))
     }
 }
@@ -59,7 +64,7 @@ impl std::convert::From<&PrivateKey> for PublicKey {
 impl PrivateKey {
     /// Load private key from a base64 encoded string.
     pub fn from_base64(key: &str) -> Result<Self, EncryptError> {
-        let keydata = base64::decode(key).map_err(EncryptError::DecodeBase64Error)?;
+        let keydata = base64::decode(key)?;
         Ok(PrivateKey(keydata))
     }
 }


### PR DESCRIPTION
Implementing the standard trait allows these errors to be used with
various error handling libraries such as `anyhow`. The `thiserror` crate
is used to make the implementation as concise and well-behaved as
possible.