### PR TITLE
add accumulate_vector utility function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prio"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Josh Aas <jaas@kflag.net>", "Karl Tarbe <tarbe@apple.com>"]
 edition = "2018"
 description = "Implementation of the Prio aggregation system core: https://crypto.stanford.edu/prio/"
@@ -16,6 +16,9 @@ base64 = "0.12.3"
 rand = "0.7"
 ring = "0.16.15"
 thiserror = "1.0"
+
+[dev-dependencies]
+assert_matches = "1.5.0"
 
 [[example]]
 name = "sum"

--- a/examples/sum.rs
+++ b/examples/sum.rs
@@ -68,6 +68,6 @@ fn main() {
     let _ = server1.aggregate(&share2_1, &v2_1, &v2_2).unwrap();
     let _ = server2.aggregate(&share2_2, &v2_1, &v2_2).unwrap();
 
-    server1.merge_total_shares(server2.total_shares());
+    server1.merge_total_shares(server2.total_shares()).unwrap();
     println!("Final Publication: {:?}", server1.total_shares());
 }


### PR DESCRIPTION
Adds a function `accumulate_vector` which sums one `&[Field]` into
another independently from `Server`. Since this changes the public API
`Server::merge_total_shares` (which now returns an error if the vector
lengths do not match), this also bumps the crate version to 0.3.0 to
avoid breaking existing clients.