### PR TITLE
fp: Remove no-op multiplications from FieldParameters::pow

### DIFF
--- a/src/fp.rs
+++ b/src/fp.rs
@@ -146,7 +146,7 @@ impl FieldParameters {
     /// runtime of this algorithm is linear in the bit length of `exp`.
     pub fn pow(&self, x: u128, exp: u128) -> u128 {
         let mut t = self.elem(1);
-        for i in (0..128).rev() {
+        for i in (0..128 - exp.leading_zeros()).rev() {
             t = self.mul(t, t);
             if (exp >> i) & 1 != 0 {
                 t = self.mul(t, x);


### PR DESCRIPTION
Don't count leading zeros of exponent in the for-loop in FieldParameters::pow(). This speed up should be noticeable for smaller  fields. Note that the runtime already depends on the exponent, so this isn't a degradation in terms of constant-timeness.