### PR TITLE
license: add ISRG copyright line

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+Copyright 2021 ISRG, except where otherwise noted. All rights reserved.
+
 Mozilla Public License Version 2.0
 ==================================
 


### PR DESCRIPTION
Explicitly attributes copyright to ISRG, except where individual files
assign copyright elsewhere.