### PR TITLE
Return `Result` from `Server` methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "prio"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Josh Aas <jaas@kflag.net>", "Karl Tarbe <tarbe@apple.com>"]
 edition = "2018"
 description = "Implementation of the Prio aggregation system core: https://crypto.stanford.edu/prio/"

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,10 +3,12 @@
 
 //! Prio client
 
-use crate::encrypt::*;
-use crate::field::FieldElement;
-use crate::polynomial::*;
-use crate::util::*;
+use crate::{
+    encrypt::{encrypt_share, EncryptError, PublicKey},
+    field::FieldElement,
+    polynomial::{poly_fft, PolyAuxMemory},
+    util::{proof_length, serialize, unpack_proof_mut, vector_with_length},
+};
 
 use std::convert::TryFrom;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,11 +19,3 @@ mod polynomial;
 mod prng;
 pub mod server;
 pub mod util;
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}

--- a/src/server.rs
+++ b/src/server.rs
@@ -97,8 +97,8 @@ impl<F: FieldElement> Server<F> {
         &mut self,
         eval_at: F,
         share: &[u8],
-    ) -> Option<VerificationMessage<F>> {
-        let share_field = self.deserialize_share(share).ok()?;
+    ) -> Result<VerificationMessage<F>, ServerError> {
+        let share_field = self.deserialize_share(share)?;
         generate_verification_message(
             self.dimension,
             eval_at,
@@ -182,7 +182,7 @@ pub fn generate_verification_message<F: FieldElement>(
     proof: &[F],
     is_first_server: bool,
     mem: &mut ValidationMemory<F>,
-) -> Option<VerificationMessage<F>> {
+) -> Result<VerificationMessage<F>, ServerError> {
     let unpacked = unpack_proof(proof, dimension)?;
     let proof_length = 2 * (dimension + 1).next_power_of_two();
 
@@ -235,8 +235,7 @@ pub fn generate_verification_message<F: FieldElement>(
         &mut mem.poly_mem.fft_memory,
     );
 
-    let vm = VerificationMessage { f_r, g_r, h_r };
-    Some(vm)
+    Ok(VerificationMessage { f_r, g_r, h_r })
 }
 
 /// Decides if the distributed proof is valid

--- a/tests/tweaks.rs
+++ b/tests/tweaks.rs
@@ -1,11 +1,13 @@
 // Copyright (c) 2020 Apple Inc.
 // SPDX-License-Identifier: MPL-2.0
 
-use prio::client::*;
-use prio::encrypt::*;
-use prio::field::Field32;
-use prio::server::*;
-use prio::util::*;
+use prio::{
+    client::Client,
+    encrypt::{decrypt_share, encrypt_share, PrivateKey, PublicKey},
+    field::Field32,
+    server::Server,
+    util::{deserialize, serialize, unpack_proof_mut, vector_with_length},
+};
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum Tweak {


### PR DESCRIPTION
The remaining methods on `Server` which returned `Option<Something>` now return `Result<Something, ServerError>`, to make it easier for `prio-server` to tell errors apart ([#550](https://github.com/abetterinternet/prio-server/issues/550)).