### PR TITLE
Add serde for VerificationMessage

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,14 @@ base64 = "0.12.3"
 rand = "0.7"
 ring = "0.16.15"
 thiserror = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 
 [dev-dependencies]
 assert_matches = "1.5.0"
 criterion = "0.3"
 modinverse = "0.1.0"
 num-bigint = "0.4.0"
+serde_json = "1.0"
 
 [[bench]]
 name = "fft"

--- a/examples/sum.rs
+++ b/examples/sum.rs
@@ -8,12 +8,12 @@ use prio::server::*;
 fn main() {
     let priv_key1 = PrivateKey::from_base64(
         "BIl6j+J6dYttxALdjISDv6ZI4/VWVEhUzaS05LgrsfswmbLOgN\
-        t9HUC2E0w+9RqZx3XMkdEHBHfNuCSMpOwofVSq3TfyKwn0NrftKisKKVSaTOt5seJ67P5QL4hxgPWvxw==",
+         t9HUC2E0w+9RqZx3XMkdEHBHfNuCSMpOwofVSq3TfyKwn0NrftKisKKVSaTOt5seJ67P5QL4hxgPWvxw==",
     )
     .unwrap();
     let priv_key2 = PrivateKey::from_base64(
         "BNNOqoU54GPo+1gTPv+hCgA9U2ZCKd76yOMrWa1xTWgeb4LhF\
-        LMQIQoRwDVaW64g/WTdcxT4rDULoycUNFB60LER6hPEHg/ObBnRPV1rwS3nj9Bj0tbjVPPyL9p8QW8B+w==",
+         LMQIQoRwDVaW64g/WTdcxT4rDULoycUNFB60LER6hPEHg/ObBnRPV1rwS3nj9Bj0tbjVPPyL9p8QW8B+w==",
     )
     .unwrap();
 

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -175,11 +175,11 @@ mod tests {
     fn test_encrypt_decrypt() -> Result<(), EncryptError> {
         let pub_key = PublicKey::from_base64(
             "BIl6j+J6dYttxALdjISDv6ZI4/VWVEhUzaS05LgrsfswmbLOgNt9\
-        HUC2E0w+9RqZx3XMkdEHBHfNuCSMpOwofVQ=",
+             HUC2E0w+9RqZx3XMkdEHBHfNuCSMpOwofVQ=",
         )?;
         let priv_key = PrivateKey::from_base64(
             "BIl6j+J6dYttxALdjISDv6ZI4/VWVEhUzaS05LgrsfswmbLOgN\
-        t9HUC2E0w+9RqZx3XMkdEHBHfNuCSMpOwofVSq3TfyKwn0NrftKisKKVSaTOt5seJ67P5QL4hxgPWvxw==",
+             t9HUC2E0w+9RqZx3XMkdEHBHfNuCSMpOwofVSq3TfyKwn0NrftKisKKVSaTOt5seJ67P5QL4hxgPWvxw==",
         )?;
         let data = (0..100).map(|_| rand::random::<u8>()).collect::<Vec<u8>>();
         let encrypted = encrypt_share(&data, &pub_key)?;
@@ -195,23 +195,23 @@ mod tests {
         let share2 = base64::decode("hu+vT3+8/taHP7B/dWXh/g==").unwrap();
         let encrypted_share1 = base64::decode(
             "BEWObg41JiMJglSEA6Ebk37xOeflD2a1t2eiLmX0OPccJhAER5NmOI+4r4Cfm7aJn141sGKnTbCuIB9+AeVuw\
-            MAQnzjsGPu5aNgkdpp+6VowAcVAV1DlzZvtwlQkCFlX4f3xmafTPFTPOokYi2a+H1n8GKwd",
+             MAQnzjsGPu5aNgkdpp+6VowAcVAV1DlzZvtwlQkCFlX4f3xmafTPFTPOokYi2a+H1n8GKwd",
         )
         .unwrap();
         let encrypted_share2 = base64::decode(
             "BNRzQ6TbqSc4pk0S8aziVRNjWm4DXQR5yCYTK2w22iSw4XAPW4OB9RxBpWVa1C/3ywVBT/3yLArOMXEsCEMOG\
-            1+d2CiEvtuU1zADH2MVaCnXL/dVXkDchYZsvPWPkDcjQA==",
+             1+d2CiEvtuU1zADH2MVaCnXL/dVXkDchYZsvPWPkDcjQA==",
         )
         .unwrap();
 
         let priv_key1 = PrivateKey::from_base64(
             "BIl6j+J6dYttxALdjISDv6ZI4/VWVEhUzaS05LgrsfswmbLOg\
-        Nt9HUC2E0w+9RqZx3XMkdEHBHfNuCSMpOwofVSq3TfyKwn0NrftKisKKVSaTOt5seJ67P5QL4hxgPWvxw==",
+             Nt9HUC2E0w+9RqZx3XMkdEHBHfNuCSMpOwofVSq3TfyKwn0NrftKisKKVSaTOt5seJ67P5QL4hxgPWvxw==",
         )
         .unwrap();
         let priv_key2 = PrivateKey::from_base64(
             "BNNOqoU54GPo+1gTPv+hCgA9U2ZCKd76yOMrWa1xTWgeb4LhF\
-        LMQIQoRwDVaW64g/WTdcxT4rDULoycUNFB60LER6hPEHg/ObBnRPV1rwS3nj9Bj0tbjVPPyL9p8QW8B+w==",
+             LMQIQoRwDVaW64g/WTdcxT4rDULoycUNFB60LER6hPEHg/ObBnRPV1rwS3nj9Bj0tbjVPPyL9p8QW8B+w==",
         )
         .unwrap();
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -4,6 +4,7 @@
 //! Finite field arithmetic over a prime field using a 32bit prime.
 
 use crate::fp::{FP126, FP32, FP64, FP80};
+use serde::{Deserialize, Serialize};
 use std::{
     cmp::min,
     convert::TryFrom,
@@ -104,7 +105,7 @@ macro_rules! make_field {
         $elem:ident, $int:ident, $fp:ident, $bytes:literal
     ) => {
         $(#[$meta])*
-        #[derive(Clone, Copy, Debug, PartialOrd, Ord, Hash, Default)]
+        #[derive(Clone, Copy, Debug, PartialOrd, Ord, Hash, Default, Deserialize, Serialize)]
         pub struct $elem(u128);
 
         impl PartialEq for $elem {

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,6 +9,7 @@ use crate::{
     prng::extract_share_from_seed,
     util::{deserialize, proof_length, unpack_proof, vector_with_length, SerializeError},
 };
+use serde::{Deserialize, Serialize};
 
 /// Possible errors from server operations
 #[derive(Debug, thiserror::Error)]
@@ -164,6 +165,7 @@ impl<F: FieldElement> Server<F> {
 }
 
 /// Verification message for proof validation
+#[derive(Debug, Serialize, Deserialize)]
 pub struct VerificationMessage<F: FieldElement> {
     /// f evaluated at random point
     pub f_r: F,
@@ -255,6 +257,7 @@ mod tests {
     use super::*;
     use crate::field::Field32;
     use crate::util;
+    use serde_json;
 
     #[test]
     fn test_validation() {
@@ -276,5 +279,32 @@ mod tests {
         let v2 = generate_verification_message(dim, eval_at, &share2, false, &mut validation_mem)
             .unwrap();
         assert_eq!(is_valid_share(&v1, &v2), true);
+    }
+
+    #[test]
+    fn test_verification_message_serde() {
+        let dim = 8;
+        let proof_u32: Vec<u32> = vec![
+            1, 0, 0, 0, 0, 0, 0, 0, 2052337230, 3217065186, 1886032198, 2533724497, 397524722,
+            3820138372, 1535223968, 4291254640, 3565670552, 2447741959, 163741941, 335831680,
+            2567182742, 3542857140, 124017604, 4201373647, 431621210, 1618555683, 267689149,
+        ];
+
+        let mut proof: Vec<Field32> = proof_u32.iter().map(|x| Field32::from(*x)).collect();
+        let share2 = util::tests::secret_share(&mut proof);
+        let eval_at = Field32::from(12313);
+
+        let mut validation_mem = ValidationMemory::new(dim);
+
+        let v1 =
+            generate_verification_message(dim, eval_at, &proof, true, &mut validation_mem).unwrap();
+        let v2 = generate_verification_message(dim, eval_at, &share2, false, &mut validation_mem)
+            .unwrap();
+
+        // serialize and deserialize the first verification message
+        let serialized = serde_json::to_string(&v1).unwrap();
+        let deserialized: VerificationMessage<Field32> = serde_json::from_str(&serialized).unwrap();
+
+        assert_eq!(is_valid_share(&deserialized, &v2), true);
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! Prio server
-
 use crate::{
     encrypt::{decrypt_share, EncryptError, PrivateKey},
     field::{merge_vector, FieldElement, FieldError},

--- a/tests/accumulating.rs
+++ b/tests/accumulating.rs
@@ -12,12 +12,12 @@ fn accumulation() {
     let number_of_clients = 100;
     let priv_key1 = PrivateKey::from_base64(
         "BIl6j+J6dYttxALdjISDv6ZI4/VWVEhUzaS05LgrsfswmbLOgNt9HUC2E0w+9Rq\
-        Zx3XMkdEHBHfNuCSMpOwofVSq3TfyKwn0NrftKisKKVSaTOt5seJ67P5QL4hxgPWvxw==",
+         Zx3XMkdEHBHfNuCSMpOwofVSq3TfyKwn0NrftKisKKVSaTOt5seJ67P5QL4hxgPWvxw==",
     )
     .unwrap();
     let priv_key2 = PrivateKey::from_base64(
         "BNNOqoU54GPo+1gTPv+hCgA9U2ZCKd76yOMrWa1xTWgeb4LhFLMQIQoRwDVaW64g\
-        /WTdcxT4rDULoycUNFB60LER6hPEHg/ObBnRPV1rwS3nj9Bj0tbjVPPyL9p8QW8B+w==",
+         /WTdcxT4rDULoycUNFB60LER6hPEHg/ObBnRPV1rwS3nj9Bj0tbjVPPyL9p8QW8B+w==",
     )
     .unwrap();
 

--- a/tests/tweaks.rs
+++ b/tests/tweaks.rs
@@ -28,13 +28,13 @@ fn tweaks(tweak: Tweak) {
 
     let priv_key1 = PrivateKey::from_base64(
         "BIl6j+J6dYttxALdjISDv6ZI4/VWVEhUzaS05LgrsfswmbLOgNt9HUC2E0w+9Rq\
-        Zx3XMkdEHBHfNuCSMpOwofVSq3TfyKwn0NrftKisKKVSaTOt5seJ67P5QL4hxgPWvxw==",
+         Zx3XMkdEHBHfNuCSMpOwofVSq3TfyKwn0NrftKisKKVSaTOt5seJ67P5QL4hxgPWvxw==",
     )
     .unwrap();
 
     let priv_key2 = PrivateKey::from_base64(
         "BNNOqoU54GPo+1gTPv+hCgA9U2ZCKd76yOMrWa1xTWgeb4LhFLMQIQoRwDVaW64g\
-        /WTdcxT4rDULoycUNFB60LER6hPEHg/ObBnRPV1rwS3nj9Bj0tbjVPPyL9p8QW8B+w==",
+         /WTdcxT4rDULoycUNFB60LER6hPEHg/ObBnRPV1rwS3nj9Bj0tbjVPPyL9p8QW8B+w==",
     )
     .unwrap();
 


### PR DESCRIPTION
This adds some basic serialization for the VerificationMessage. I need to take a deeper dive to tackle #24 (for example, why do field elements serialize to a variable number of bytes when it's derived from a u128 and the field parameters [here](https://github.com/abetterinternet/libprio-rs/blob/b68a16b04cfa0d62bc3ba02ae264685a2930116e/src/field.rs#L275) and [here](https://github.com/abetterinternet/libprio-rs/blob/b68a16b04cfa0d62bc3ba02ae264685a2930116e/src/fp.rs#L187)? edit: nevermind, I see now). 

This should be enough to allow usage of the public api in an application that wants to use serde for transporting messages. I used json_serde in the tests here. 