### PR TITLE
ParallelPolyCheckedVector

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ aes-ctr = "0.4.0"
 aes-gcm = "0.6.0"
 base64 = "0.12.3"
 rand = "0.7"
+rayon = "1.5"
 ring = "0.16.15"
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -7,7 +7,7 @@ use prio::client::Client;
 use prio::encrypt::PublicKey;
 use prio::field::{Field126 as F, FieldElement};
 use prio::pcp::gadgets::Mul;
-use prio::pcp::types::PolyCheckedVector;
+use prio::pcp::types::{ParallelPolyCheckedVector, PolyCheckedVector};
 use prio::pcp::{prove, query, Gadget, Value};
 use prio::server::{generate_verification_message, ValidationMemory};
 
@@ -128,6 +128,32 @@ pub fn bool_vec(c: &mut Criterion) {
                 query(&x, &pf, &query_rand, &joint_rand).unwrap();
             })
         });
+
+        // v3 (parallel)
+        let x: ParallelPolyCheckedVector<F> =
+            ParallelPolyCheckedVector::new_range_checked(data.clone(), 0, 2);
+        let (query_rand, joint_rand) = gen_rand(&x);
+
+        c.bench_function(
+            &format!("bool vec v3 parallel prove, size={}", *size),
+            |b| {
+                b.iter(|| {
+                    prove(&x, &joint_rand).unwrap();
+                })
+            },
+        );
+
+        let pf = prove(&x, &joint_rand).unwrap();
+        println!("bool vec v3 parallel proof size={}\n", pf.as_slice().len());
+
+        c.bench_function(
+            &format!("bool vec v3 parallel query, size={}", *size),
+            |b| {
+                b.iter(|| {
+                    query(&x, &pf, &query_rand, &joint_rand).unwrap();
+                })
+            },
+        );
     }
 }
 

--- a/src/field.rs
+++ b/src/field.rs
@@ -30,6 +30,8 @@ pub enum FieldError {
 /// Objects with this trait represent an element of `GF(p)` for some prime `p`.
 pub trait FieldElement:
     Sized
+    + Send
+    + Sync
     + Debug
     + Copy
     + PartialEq

--- a/src/field.rs
+++ b/src/field.rs
@@ -370,6 +370,7 @@ pub fn merge_vector<F: FieldElement>(
     Ok(())
 }
 
+#[cfg(test)]
 pub(crate) fn rand_vec<F: FieldElement>(len: usize) -> Vec<F> {
     let mut outp: Vec<F> = Vec::with_capacity(len);
     for _ in 0..len {

--- a/src/pcp.rs
+++ b/src/pcp.rs
@@ -234,9 +234,13 @@ pub trait GadgetCallOnly<F: FieldElement> {
 
 /// The sub-circuit associated with some validity circuit. A gadget is called either on a sequence
 /// of finite field elements or a sequence of polynomials over a finite field.
-pub trait Gadget<F: FieldElement>: GadgetCallOnly<F> {
+pub trait Gadget<F: FieldElement>: GadgetCallOnly<F> + Clone + Sync + Send {
     /// Evaluate the gadget on input of a sequence of polynomials. The output is written to `outp`.
-    fn call_poly<V: AsRef<[F]>>(&mut self, outp: &mut [F], inp: &[V]) -> Result<(), PcpError>;
+    fn call_poly<V: Sync + AsRef<[F]>>(
+        &mut self,
+        outp: &mut [F],
+        inp: &[V],
+    ) -> Result<(), PcpError>;
 
     /// The maximum degree of the polynomial output by `call_poly` as a function of the maximum
     /// degree of each input polynomial.

--- a/src/pcp/gadgets.rs
+++ b/src/pcp/gadgets.rs
@@ -7,13 +7,17 @@ use crate::field::FieldElement;
 use crate::pcp::{Gadget, GadgetCallOnly, PcpError};
 use crate::polynomial::{poly_deg, poly_eval, poly_mul};
 
+use rayon::prelude::*;
+
 use std::convert::TryFrom;
+use std::marker::PhantomData;
 
 /// For input polynomials larger than or equal to this threshold, gadgets will use FFT for
 /// polynomial multiplication. Otherwise, the gadget uses direct multiplication.
 const FFT_THRESHOLD: usize = 60;
 
 /// An arity-2 gadget that multiples its inputs.
+#[derive(Clone)]
 pub struct Mul<F: FieldElement> {
     /// Size of buffer for FFT operations.
     n: usize,
@@ -91,6 +95,7 @@ impl<F: FieldElement> Gadget<F> for Mul<F> {
 }
 
 /// An arity-1 gadget that evaluates its input on some polynomial.
+#[derive(Clone)]
 pub struct PolyEval<F: FieldElement> {
     poly: Vec<F>,
     /// Size of buffer for FFT operations.
@@ -107,54 +112,53 @@ impl<F: FieldElement> PolyEval<F> {
         let n_inv = F::from(F::Integer::try_from(n).unwrap()).inv();
         Self { poly, n, n_inv }
     }
-}
 
-impl<F: FieldElement> PolyEval<F> {
-    // Multiply input polynomials directly.
     fn call_poly_direct<V: AsRef<[F]>>(
         &mut self,
         outp: &mut [F],
         inp: &[V],
     ) -> Result<(), PcpError> {
         outp[0] = self.poly[0];
-        let mut x = inp[0].as_ref().to_vec();
+        let x = inp[0].as_ref();
+        let mut z = x.to_vec();
         for i in 1..self.poly.len() {
-            for j in 0..x.len() {
-                outp[j] += self.poly[i] * x[j];
+            for j in 0..z.len() {
+                outp[j] += self.poly[i] * z[j];
             }
 
             if i < self.poly.len() - 1 {
-                x = poly_mul(&x, inp[0].as_ref());
+                z = poly_mul(&z, x);
             }
         }
         Ok(())
     }
 
-    // Multiply input polynomials using FFT.
     fn call_poly_fft<V: AsRef<[F]>>(&mut self, outp: &mut [F], inp: &[V]) -> Result<(), PcpError> {
         let n = self.n;
-        let inp = inp[0].as_ref();
+        let x = inp[0].as_ref();
 
-        let mut inp_vals = vec![F::zero(); n];
-        discrete_fourier_transform(&mut inp_vals, inp, n)?;
+        let mut x_vals = vec![F::zero(); n];
+        discrete_fourier_transform(&mut x_vals, x, n)?;
 
-        let mut x_vals = inp_vals.clone();
-        let mut x = vec![F::zero(); n];
-        x[..inp.len()].clone_from_slice(inp);
+        let mut z_vals = x_vals.clone();
+        let mut z = vec![F::zero(); n];
+        let mut z_len = x.len();
+        z[..x.len()].clone_from_slice(x);
 
         outp[0] = self.poly[0];
         for i in 1..self.poly.len() {
-            for j in 0..outp.len() {
-                outp[j] += self.poly[i] * x[j];
+            for j in 0..z_len {
+                outp[j] += self.poly[i] * z[j];
             }
 
             if i < self.poly.len() - 1 {
                 for j in 0..n {
-                    x_vals[j] *= inp_vals[j];
+                    z_vals[j] *= x_vals[j];
                 }
 
-                discrete_fourier_transform(&mut x, &x_vals, n)?;
-                discrete_fourier_transform_inv_finish(&mut x, n, self.n_inv);
+                discrete_fourier_transform(&mut z, &z_vals, n)?;
+                discrete_fourier_transform_inv_finish(&mut z, n, self.n_inv);
+                z_len += x.len();
             }
         }
         Ok(())
@@ -189,6 +193,184 @@ impl<F: FieldElement> Gadget<F> for PolyEval<F> {
 
     fn call_poly_out_len(&self, in_len: usize) -> usize {
         poly_deg(&self.poly) * in_len
+    }
+}
+
+/// An arity-2 gadget that returns `poly(in[0]) * in[1]` for some polynomial `poly`.
+#[derive(Clone)]
+pub struct BlindPolyEval<F: FieldElement> {
+    poly: Vec<F>,
+    /// Size of buffer for the outer FFT multiplication.
+    n: usize,
+    /// Inverse of `n` in `F`.
+    n_inv: F,
+}
+
+impl<F: FieldElement> BlindPolyEval<F> {
+    /// Returns a `BlindPolyEval` gadget for polynomial `poly`. Integer `in_len` is the length of
+    /// the input polynomials on which `call_poly` will be called.
+    pub fn new(poly: Vec<F>, in_len: usize) -> Self {
+        let n = (in_len * (poly_deg(&poly) + 1)).next_power_of_two();
+        let n_inv = F::from(F::Integer::try_from(n).unwrap()).inv();
+        Self { poly, n, n_inv }
+    }
+
+    fn call_poly_direct<V: AsRef<[F]>>(
+        &mut self,
+        outp: &mut [F],
+        inp: &[V],
+    ) -> Result<(), PcpError> {
+        let x = inp[0].as_ref();
+        let y = inp[1].as_ref();
+
+        let mut z = y.to_vec();
+        for i in 0..self.poly.len() {
+            for j in 0..z.len() {
+                outp[j] += self.poly[i] * z[j];
+            }
+
+            if i < self.poly.len() - 1 {
+                z = poly_mul(&z, x);
+            }
+        }
+        Ok(())
+    }
+
+    fn call_poly_fft<V: AsRef<[F]>>(&mut self, outp: &mut [F], inp: &[V]) -> Result<(), PcpError> {
+        let n = self.n;
+        let x = inp[0].as_ref();
+        let y = inp[1].as_ref();
+
+        let mut x_vals = vec![F::zero(); n];
+        discrete_fourier_transform(&mut x_vals, x, n)?;
+
+        let mut z_vals = vec![F::zero(); n];
+        discrete_fourier_transform(&mut z_vals, y, n)?;
+
+        let mut z = vec![F::zero(); n];
+        let mut z_len = y.len();
+        z[..y.len()].clone_from_slice(y);
+
+        for i in 0..self.poly.len() {
+            for j in 0..z_len {
+                outp[j] += self.poly[i] * z[j];
+            }
+
+            if i < self.poly.len() - 1 {
+                for j in 0..n {
+                    z_vals[j] *= x_vals[j];
+                }
+
+                discrete_fourier_transform(&mut z, &z_vals, n)?;
+                discrete_fourier_transform_inv_finish(&mut z, n, self.n_inv);
+                z_len += x.len();
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<F: FieldElement> GadgetCallOnly<F> for BlindPolyEval<F> {
+    fn call(&mut self, inp: &[F]) -> Result<F, PcpError> {
+        gadget_call_check(self, inp.len())?;
+        Ok(inp[1] * poly_eval(&self.poly, inp[0]))
+    }
+
+    fn call_in_len(&self) -> usize {
+        2
+    }
+}
+
+impl<F: FieldElement> Gadget<F> for BlindPolyEval<F> {
+    fn call_poly<V: AsRef<[F]>>(&mut self, outp: &mut [F], inp: &[V]) -> Result<(), PcpError> {
+        gadget_call_poly_check(self, outp, inp)?;
+
+        for i in 0..outp.len() {
+            outp[i] = F::zero();
+        }
+
+        if inp[0].as_ref().len() >= FFT_THRESHOLD {
+            self.call_poly_fft(outp, inp)
+        } else {
+            self.call_poly_direct(outp, inp)
+        }
+    }
+
+    fn call_poly_out_len(&self, in_len: usize) -> usize {
+        (poly_deg(&self.poly) + 1) * in_len
+    }
+}
+
+/// A wrapper gadget that applies the inner gadget to chunks of input and returns the sum of the
+/// outputs. The arity is equal to the arity of the inner gadget times the number of chunks.
+#[derive(Clone)]
+pub struct ParallelSum<F: FieldElement, G: Gadget<F>> {
+    inner: G,
+    chunks: usize,
+    phantom: PhantomData<F>,
+}
+
+impl<F: FieldElement, G: Gadget<F>> ParallelSum<F, G> {
+    /// Wraps `inner` into a parallel sum gadget with `chunks` chunks.
+    pub fn new(inner: G, chunks: usize) -> Self {
+        Self {
+            inner,
+            chunks,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<F: FieldElement, G: Gadget<F>> GadgetCallOnly<F> for ParallelSum<F, G> {
+    fn call(&mut self, inp: &[F]) -> Result<F, PcpError> {
+        gadget_call_check(self, inp.len())?;
+        let mut outp = F::zero();
+        for chunk in inp.chunks(self.inner.call_in_len()) {
+            outp += self.inner.call(chunk)?;
+        }
+        Ok(outp)
+    }
+
+    fn call_in_len(&self) -> usize {
+        self.chunks * self.inner.call_in_len()
+    }
+}
+
+impl<F: FieldElement, G: Gadget<F>> Gadget<F> for ParallelSum<F, G> {
+    fn call_poly<V: Sync + AsRef<[F]>>(
+        &mut self,
+        outp: &mut [F],
+        inp: &[V],
+    ) -> Result<(), PcpError> {
+        gadget_call_poly_check(self, outp, inp)?;
+
+        let res = inp
+            .par_chunks(self.inner.call_in_len())
+            .map(|chunk| {
+                let mut inner = self.inner.clone();
+                let mut partial_outp = vec![F::zero(); outp.len()];
+                inner.call_poly(&mut partial_outp, chunk).unwrap();
+                partial_outp
+            })
+            .reduce(
+                || vec![F::zero(); outp.len()],
+                |mut x, y| {
+                    for i in 0..x.len() {
+                        x[i] += y[i];
+                    }
+                    x
+                },
+            );
+
+        for i in 0..outp.len() {
+            outp[i] = res[i];
+        }
+
+        Ok(())
+    }
+
+    fn call_poly_out_len(&self, in_len: usize) -> usize {
+        self.inner.call_poly_out_len(in_len)
     }
 }
 
@@ -237,6 +419,7 @@ mod tests {
     use super::*;
 
     use crate::field::{rand_vec, Field80 as TestField};
+    use crate::polynomial::poly_range_check;
 
     #[test]
     fn test_mul() {
@@ -266,21 +449,41 @@ mod tests {
         gadget_test(&mut g, in_len);
     }
 
+    #[test]
+    fn test_blind_poly_eval() {
+        let poly = rand_vec(10);
+
+        let in_len = FFT_THRESHOLD - 1;
+        let mut g: BlindPolyEval<TestField> = BlindPolyEval::new(poly.clone(), in_len);
+        gadget_test(&mut g, in_len);
+
+        let in_len = FFT_THRESHOLD.next_power_of_two();
+        let mut g: BlindPolyEval<TestField> = BlindPolyEval::new(poly.clone(), in_len);
+        gadget_test(&mut g, in_len);
+    }
+
+    #[test]
+    fn test_parallel_sum() {
+        let in_len = 10;
+        let mut g: ParallelSum<TestField, BlindPolyEval<TestField>> =
+            ParallelSum::new(BlindPolyEval::new(poly_range_check(0, 2), in_len), 23);
+        gadget_test(&mut g, in_len);
+    }
+
     // Test that calling g.call_poly() and evaluating the output at a given point is equivalent
     // to evaluating each of the inputs at the same point and applying g.call() on the results.
     fn gadget_test<F: FieldElement, G: GadgetCallOnly<F>>(g: &mut G, in_len: usize)
     where
         G: Gadget<F>,
     {
-        let mut inp = vec![F::zero(); g.call_in_len()];
+        let l = g.call_in_len();
+        let mut inp = vec![F::zero(); l];
         let mut poly_outp = vec![F::zero(); g.call_poly_out_len(in_len)];
-        let mut poly_inp = vec![vec![F::zero(); in_len]; g.call_in_len()];
+        let mut poly_inp = vec![vec![F::zero(); in_len]; l];
 
         let r = F::rand();
-        for i in 0..g.call_in_len() {
-            for j in 0..in_len {
-                poly_inp[i][j] = F::rand();
-            }
+        for i in 0..l {
+            poly_inp[i] = rand_vec(in_len);
             inp[i] = poly_eval(&poly_inp[i], r);
         }
 
@@ -292,6 +495,7 @@ mod tests {
         // Repeat the call to make sure that the gadget's memory is reset properly between calls.
         g.call_poly(&mut poly_outp, &poly_inp).unwrap();
         let got = poly_eval(&poly_outp, r);
+        let want = g.call(&inp).unwrap();
         assert_eq!(got, want);
     }
 }

--- a/src/pcp/types.rs
+++ b/src/pcp/types.rs
@@ -3,7 +3,7 @@
 //! A collection of data types.
 
 use crate::field::FieldElement;
-use crate::pcp::gadgets::{Mul, PolyEval};
+use crate::pcp::gadgets::{BlindPolyEval, Mul, ParallelSum, PolyEval};
 use crate::pcp::{GadgetCallOnly, PcpError, Value};
 use crate::polynomial::poly_range_check;
 
@@ -151,6 +151,100 @@ impl<F: FieldElement> Value<F, PolyEval<F>> for PolyCheckedVector<F> {
     }
 }
 
+/// Like `PolyCheckedVector`, but the proof that is generated uses the `ParallelSum` gadget in
+/// order to reduce the proof size from `O(n)` to `O(sqrt(n))`.
+#[derive(Debug, PartialEq, Eq)]
+pub struct ParallelPolyCheckedVector<F: FieldElement> {
+    data: Vec<F>,
+    poly: Vec<F>,
+    chunk_len: usize,
+}
+
+impl<F: FieldElement> ParallelPolyCheckedVector<F> {
+    /// Returns a `poly`-checked vector where `poly(x) == 0` if and only if `x` is in range
+    /// `[start, end)`. The degree of `poly` is equal to `end`.
+    pub fn new_range_checked(data: Vec<F>, start: usize, end: usize) -> Self {
+        // The optimal chunk length is the square root of the input length. If the input length is
+        // not a perfect square, then round down. If the result is 0, then let the chunk length be
+        // 1 so that the underlying gadget can still be called.
+        let chunk_len = std::cmp::max(1, (data.len() as f64).sqrt() as usize);
+        Self {
+            data,
+            poly: poly_range_check(start, end),
+            chunk_len,
+        }
+    }
+}
+
+impl<F: FieldElement> Value<F, ParallelSum<F, BlindPolyEval<F>>> for ParallelPolyCheckedVector<F> {
+    fn valid(&self, g: &mut dyn GadgetCallOnly<F>, rand: &[F]) -> Result<F, PcpError> {
+        if rand.len() != self.valid_rand_len() {
+            return Err(PcpError::ValidRandLen);
+        }
+
+        if self.data.len() == 0 {
+            return Ok(F::zero());
+        }
+
+        let mut r = rand[0];
+        let mut outp = F::zero();
+        let mut inp = vec![F::zero(); 2 * self.chunk_len];
+        for chunk in self.data.chunks(self.chunk_len) {
+            let d = chunk.len();
+            for i in 0..self.chunk_len {
+                if i < d {
+                    inp[2 * i] = chunk[i];
+                } else {
+                    // If the chunk is smaller than the chunk length, then copy the last element of
+                    // the chunk into the remaining slots.
+                    inp[2 * i] = chunk[d - 1];
+                }
+                inp[2 * i + 1] = r;
+                r *= rand[0];
+            }
+
+            outp += g.call(&inp)?;
+        }
+
+        Ok(outp)
+    }
+
+    fn valid_gadget_calls(&self) -> usize {
+        if self.data.len() == 0 {
+            return 0;
+        }
+
+        let mut g_calls = self.data.len() / self.chunk_len;
+        if self.data.len() % self.chunk_len != 0 {
+            g_calls += 1;
+        }
+        g_calls
+    }
+
+    fn valid_rand_len(&self) -> usize {
+        1
+    }
+
+    fn gadget(&self, in_len: usize) -> ParallelSum<F, BlindPolyEval<F>> {
+        ParallelSum::new(
+            BlindPolyEval::new(self.poly.clone(), in_len),
+            self.chunk_len,
+        )
+    }
+
+    fn as_slice(&self) -> &[F] {
+        &self.data
+    }
+
+    fn new_with(&self, data: Vec<F>) -> Self {
+        Self {
+            data,
+            poly: self.poly.clone(),
+            chunk_len: self.chunk_len,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -165,6 +259,7 @@ mod tests {
     struct ValidityTestCase {
         expect_valid: bool,
         expected_proof_len: usize,
+        joint_rand_leader_only: bool,
     }
 
     #[test]
@@ -175,6 +270,7 @@ mod tests {
             &ValidityTestCase {
                 expect_valid: true,
                 expected_proof_len: 9,
+                joint_rand_leader_only: false,
             },
         );
         pcp_validity_test(
@@ -182,6 +278,7 @@ mod tests {
             &ValidityTestCase {
                 expect_valid: true,
                 expected_proof_len: 9,
+                joint_rand_leader_only: false,
             },
         );
 
@@ -194,6 +291,7 @@ mod tests {
             &ValidityTestCase {
                 expect_valid: false,
                 expected_proof_len: 9,
+                joint_rand_leader_only: false,
             },
         );
 
@@ -234,6 +332,7 @@ mod tests {
             &ValidityTestCase {
                 expect_valid: true,
                 expected_proof_len: 137,
+                joint_rand_leader_only: false,
             },
         );
         pcp_validity_test(
@@ -244,6 +343,7 @@ mod tests {
             &ValidityTestCase {
                 expect_valid: true,
                 expected_proof_len: 2,
+                joint_rand_leader_only: false,
             },
         );
         pcp_validity_test(
@@ -254,6 +354,7 @@ mod tests {
             &ValidityTestCase {
                 expect_valid: true,
                 expected_proof_len: 4,
+                joint_rand_leader_only: false,
             },
         );
         pcp_validity_test(
@@ -264,6 +365,7 @@ mod tests {
             &ValidityTestCase {
                 expect_valid: true,
                 expected_proof_len: 32,
+                joint_rand_leader_only: false,
             },
         );
 
@@ -276,6 +378,7 @@ mod tests {
             &ValidityTestCase {
                 expect_valid: false,
                 expected_proof_len: 8,
+                joint_rand_leader_only: false,
             },
         );
         pcp_validity_test(
@@ -286,6 +389,90 @@ mod tests {
             &ValidityTestCase {
                 expect_valid: false,
                 expected_proof_len: 16,
+                joint_rand_leader_only: false,
+            },
+        );
+    }
+
+    #[test]
+    fn test_parallel_poly_checked_vector() {
+        let one = TestField::one();
+        let zero = TestField::zero();
+        let nine = TestField::from(<TestField as FieldElement>::Integer::try_from(9).unwrap());
+
+        // Test PCP on valid input.
+        pcp_validity_test(
+            &ParallelPolyCheckedVector::<TestField>::new_range_checked(
+                vec![zero, one, one, one, one, one, one, one, one],
+                0,
+                2,
+            ),
+            &ValidityTestCase {
+                expect_valid: true,
+                expected_proof_len: 16,
+                joint_rand_leader_only: true,
+            },
+        );
+        pcp_validity_test(
+            &ParallelPolyCheckedVector::<TestField>::new_range_checked(vec![], 0, 2),
+            &ValidityTestCase {
+                expect_valid: true,
+                expected_proof_len: 3,
+                joint_rand_leader_only: true,
+            },
+        );
+        pcp_validity_test(
+            &ParallelPolyCheckedVector::<TestField>::new_range_checked(vec![nine], 0, 13),
+            &ValidityTestCase {
+                expect_valid: true,
+                expected_proof_len: 17,
+                joint_rand_leader_only: true,
+            },
+        );
+        pcp_validity_test(
+            &ParallelPolyCheckedVector::<TestField> {
+                data: vec![one, zero, one, one, zero],
+                poly: poly_range_check(0, 2),
+                chunk_len: 4,
+            },
+            &ValidityTestCase {
+                expect_valid: true,
+                expected_proof_len: 18,
+                joint_rand_leader_only: true,
+            },
+        );
+
+        // Test PCP on invalid data.
+        pcp_validity_test(
+            &ParallelPolyCheckedVector::<TestField>::new_range_checked(vec![zero, nine, one], 0, 2),
+            &ValidityTestCase {
+                expect_valid: false,
+                expected_proof_len: 12,
+                joint_rand_leader_only: true,
+            },
+        );
+        pcp_validity_test(
+            &ParallelPolyCheckedVector::<TestField> {
+                data: vec![one, zero, one, one, nine],
+                poly: poly_range_check(0, 2),
+                chunk_len: 4,
+            },
+            &ValidityTestCase {
+                expect_valid: false,
+                expected_proof_len: 18,
+                joint_rand_leader_only: true,
+            },
+        );
+        pcp_validity_test(
+            &ParallelPolyCheckedVector::<TestField> {
+                data: vec![one, zero, one, nine, zero],
+                poly: poly_range_check(0, 2),
+                chunk_len: 4,
+            },
+            &ValidityTestCase {
+                expect_valid: false,
+                expected_proof_len: 18,
+                joint_rand_leader_only: true,
             },
         );
     }
@@ -341,8 +528,24 @@ mod tests {
             .collect();
 
         let mut vf_shares: Vec<Verifier<F>> = Vec::with_capacity(NUM_SHARES);
+        let mut joint_rand_shares = vec![joint_rand.clone()];
+        for _ in 1..NUM_SHARES {
+            if t.joint_rand_leader_only {
+                joint_rand_shares.push(vec![F::zero(); rand_len]);
+            } else {
+                joint_rand_shares.push(joint_rand.clone());
+            }
+        }
         for i in 0..NUM_SHARES {
-            vf_shares.push(query(&x_shares[i], &pf_shares[i], &query_rand, &joint_rand).unwrap());
+            vf_shares.push(
+                query(
+                    &x_shares[i],
+                    &pf_shares[i],
+                    &query_rand,
+                    &joint_rand_shares[i],
+                )
+                .unwrap(),
+            );
         }
 
         let vf = Verifier::try_from(vf_shares.as_slice()).unwrap();


### PR DESCRIPTION
Closes #35. **This PR is WIP and is not yet ready for review. I want to go back through the paper to make sure the math is correct.**

This PR adds a new type called `ParallelPolyCheckedVector`. Like `PolyCheckedVector`, the proof system recognizes input vectors as valid iff `poly(x) == 0` holds for all elements `x`. However, the proof size is `O(sqrt(n))` instead of `O(n)`. The downside is that proof generation time is about twice as slow for small inputs. (It is faster for larger inputs due to the reduced proof size.)

This PR uses the `rayon` crate in order to parallelize computation of the proof polynomial. I'm a novice at asynchronous Rust, but my hunch is that the overhead of `rayon` is higher than we would get with a more tailored solution.

Benchmarks for vectors of booleans:

| proof system (input size) | average prove time | average query time | proof size |
|-------------------|------------|-----------|--------------|
| PolyCheckedVector (1,000) | 437.1 us | 256.1 us | 2,048 |
| ParallelPolyCheckedVector (1,000) | 1000 us | 254.0 us | 252 |
| PolyCheckedVector (10,000) | 11.1 ms | 6.2 ms | 32,768 |
| ParallelPolyCheckedVector (10,000) | 6.1 ms | 1.8 ms | 582 |
| PolyCheckedVector (100,000) | 158.ms | 88.8 ms | 262,144 |
| ParallelPolyCheckedVector (100,000) | 84.5 ms | 24.0 ms | 2,166 |