### PR TITLE
pcp: Distinguish between joint and query randomness

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -370,6 +370,7 @@ pub fn merge_vector<F: FieldElement>(
     Ok(())
 }
 
+#[cfg(test)]
 pub(crate) fn rand_vec<F: FieldElement>(len: usize) -> Vec<F> {
     let mut outp: Vec<F> = Vec::with_capacity(len);
     for _ in 0..len {


### PR DESCRIPTION
The "query randomness" is the random point at which the verifier evaluates the proof polynomial; the "joint randomness" is whatever randomness is used by both the prover and verifier. This allows us to implement proof systems like [BCG+19, Theorem 5.3] in which the verifier sends the prover a random challenge to use for proof generation.

Along the way, this PR cleans up the unit tests and benchmarks a bit.