### PR TITLE
[WIP] Changes needed for prototype

### DIFF
--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -7,7 +7,7 @@ use prio::client::Client;
 use prio::encrypt::PublicKey;
 use prio::field::{Field126 as F, FieldElement};
 use prio::pcp::gadgets::Mul;
-use prio::pcp::types::PolyCheckedVector;
+use prio::pcp::types::{MeanVarUnsignedVector, PolyCheckedVector};
 use prio::pcp::{prove, query, Gadget, Value};
 use prio::server::{generate_verification_message, ValidationMemory};
 
@@ -131,6 +131,43 @@ pub fn bool_vec(c: &mut Criterion) {
     }
 }
 
+/// XXX
+pub fn mean_var_int_vec(c: &mut Criterion) {
+    let bits = 12;
+    let test_sizes = [1, 10, 20, 100, 1_000, 10_000];
+    for size in test_sizes.iter() {
+        let data = vec![0; *size];
+
+        let x: MeanVarUnsignedVector<F> = MeanVarUnsignedVector::new(bits, &data).unwrap();
+        let (query_rand, joint_rand) = gen_rand(&x);
+
+        c.bench_function(
+            &format!("{}-bit mean var int vec prove, size={}", bits, *size),
+            |b| {
+                b.iter(|| {
+                    prove(&x, &joint_rand).unwrap();
+                })
+            },
+        );
+
+        let pf = prove(&x, &joint_rand).unwrap();
+        println!(
+            "{}-bit mean var int vec proof size={}\n",
+            bits,
+            pf.as_slice().len()
+        );
+
+        c.bench_function(
+            &format!("{}-bit mean var int vec query, size={}", bits, *size),
+            |b| {
+                b.iter(|| {
+                    query(&x, &pf, &query_rand, &joint_rand).unwrap();
+                })
+            },
+        );
+    }
+}
+
 fn gen_rand<F, G, V>(x: &V) -> (Vec<F>, Vec<F>)
 where
     F: FieldElement,
@@ -139,6 +176,7 @@ where
 {
     let query_rand = vec![F::rand()];
     let rand_len = x.valid_rand_len();
+
     let mut joint_rand: Vec<F> = Vec::with_capacity(rand_len);
     for _ in 0..rand_len {
         joint_rand.push(F::rand());
@@ -146,5 +184,5 @@ where
     (query_rand, joint_rand)
 }
 
-criterion_group!(benches, bool_vec, poly_mul, fft);
+criterion_group!(benches, mean_var_int_vec);
 criterion_main!(benches);

--- a/src/field.rs
+++ b/src/field.rs
@@ -10,11 +10,11 @@ use std::{
     cmp::min,
     convert::TryFrom,
     fmt::{Debug, Display, Formatter},
-    ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Shr, Sub, SubAssign},
+    ops::{Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Neg, Shr, Sub, SubAssign},
 };
 
 /// Possible errors from finite field operations.
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, PartialEq, thiserror::Error)]
 pub enum FieldError {
     /// Input sizes do not match
     #[error("input sizes do not match")]
@@ -56,6 +56,7 @@ pub trait FieldElement:
     type Integer: Copy
         + Debug
         + PartialOrd
+        + BitAnd<Output = <Self as FieldElement>::Integer>
         + Div<Output = <Self as FieldElement>::Integer>
         + Shr<Output = <Self as FieldElement>::Integer>
         + Sub<Output = <Self as FieldElement>::Integer>

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -215,6 +215,8 @@ pub fn poly_interpret_eval<F: FieldElement>(
 
 // Returns a polynomial that evaluates to `0` if the input is in range `[start, end)`. Otherwise,
 // the output is not `0`.
+//
+// TODO(cjpatton): Pass a range here instead of a pair `(start, end)`.
 pub(crate) fn poly_range_check<F: FieldElement>(start: usize, end: usize) -> Vec<F> {
     let mut p = vec![F::one()];
     let mut q = [F::zero(), F::one()];


### PR DESCRIPTION
Add the MeanVarUnsignedVector type, which represents a vector of
L-bit integers. The collector wants to compute the mean and variance of
each element of the vector.

Refactor prng API so that we don't have unwind the entire output for
every call.

Replace the clunky Value::new_with() call with a proper TryFrom that
takes a vector of field elements and "parameters" specified by
Value::Param. (There is also a new call Value::param() for getting the
parameters of an input.)

Add Value::set_leader() call for signaling if an input is the leader's
or a helper's share. (This seems to be useful for certain proof
systems.)

Add an interface for handling Verifier as a vector of field elements.

Move poly_range_check to the polynomial module.