### PR TITLE
pcp: Add TryFrom for Value from field sequence

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -50,7 +50,7 @@ pub trait FieldElement:
     const BYTES: usize;
 
     /// The error returned if converting `usize` to an `Int` fails.
-    type IntegerTryFromError: std::fmt::Debug;
+    type IntegerTryFromError: Debug;
 
     /// The integer representation of the field element.
     type Integer: Copy


### PR DESCRIPTION
Based on #44.

The new_with() method on Value allows a new instance of Value to be constructed from an existing instance of Value and a sequence of field elements. This is used in order construct a Value from a secret share of the underlying data. However, it requires the caller to already have an instance of Value on hand, which is usually not the case. 

This change drops new_with() in favor of a proper TryFrom supertrait on Value. The caller provides a vector of field elements as well as a "parameter", the type of which is an associated type of the particular implementation of Value.