### PR TITLE
Replace rand dependency with getrandom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ aes = { version = "0.7.3", features = ["ctr"] }
 cipher = "0.3.0"
 aes-gcm = "0.6.0"
 base64 = "0.12.3"
-rand = "0.7"
+getrandom = { version = "0.2.3", features = ["std"] }
 ring = "0.16.15"
 thiserror = "1.0"
 serde = { version = "1.0", features = ["derive"] }
@@ -24,6 +24,7 @@ assert_matches = "1.5.0"
 criterion = "0.3"
 modinverse = "0.1.0"
 num-bigint = "0.4.0"
+rand = "0.7"
 serde_json = "1.0"
 
 [[bench]]

--- a/examples/sum.rs
+++ b/examples/sum.rs
@@ -45,8 +45,8 @@ fn main() {
     let (share2_1, share2_2) = client2.encode_simple(&data2).unwrap();
     let eval_at = Field32::from(12313);
 
-    let mut server1 = Server::new(dim, true, priv_key1.clone());
-    let mut server2 = Server::new(dim, false, priv_key2.clone());
+    let mut server1 = Server::new(dim, true, priv_key1.clone()).unwrap();
+    let mut server2 = Server::new(dim, false, priv_key2.clone()).unwrap();
 
     let v1_1 = server1
         .generate_verification_message(eval_at, &share1_1)

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,6 +7,7 @@ use crate::{
     encrypt::{encrypt_share, EncryptError, PublicKey},
     field::FieldElement,
     polynomial::{poly_fft, PolyAuxMemory},
+    prng::Prng,
     util::{proof_length, serialize, unpack_proof_mut},
 };
 
@@ -92,7 +93,7 @@ impl<F: FieldElement> Client<F> {
 
         // use prng to share the proof: share2 is the PRNG seed, and proof is mutated
         // in-place
-        let share2 = crate::prng::secret_share(&mut proof);
+        let share2 = crate::prng::secret_share(&mut proof)?;
         let share1 = serialize(&proof);
         // encrypt shares with respective keys
         let encrypted_share1 = encrypt_share(&share1, &self.public_key1)?;
@@ -176,10 +177,11 @@ fn construct_proof<F: FieldElement>(
     mem: &mut Client<F>,
 ) {
     let n = (dimension + 1).next_power_of_two();
+    let mut prng = Prng::new_with_length(2).unwrap();
 
     // set zero terms to random
-    *f0 = F::rand();
-    *g0 = F::rand();
+    *f0 = prng.next().unwrap();
+    *g0 = prng.next().unwrap();
     mem.points_f[0] = *f0;
     mem.points_g[0] = *g0;
 

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -34,6 +34,9 @@ pub enum EncryptError {
     /// Input ciphertext was too small
     #[error("input ciphertext was too small")]
     DecryptionLength,
+    /// Failure when calling getrandom().
+    #[error("getrandom: {0}")]
+    GetRandom(#[from] getrandom::Error),
 }
 
 /// NIST P-256, public key in X9.62 uncompressed format

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -114,19 +114,16 @@ fn bitrev(d: usize, x: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::field::{rand_vec, split, Field126, Field32, Field64, Field80};
+    use crate::field::{rand, split, Field126, Field32, Field64, Field80};
     use crate::polynomial::{poly_fft, PolyAuxMemory};
 
     fn discrete_fourier_transform_then_inv_test<F: FieldElement>() -> Result<(), FftError> {
         let test_sizes = [1, 2, 4, 8, 16, 256, 1024, 2048];
 
         for size in test_sizes.iter() {
-            let mut want = vec![F::zero(); *size];
             let mut tmp = vec![F::zero(); *size];
             let mut got = vec![F::zero(); *size];
-            for i in 0..*size {
-                want[i] = F::rand();
-            }
+            let want = rand(*size);
 
             discrete_fourier_transform(&mut tmp, &want, want.len())?;
             discrete_fourier_transform_inv(&mut got, &tmp, tmp.len())?;
@@ -161,12 +158,9 @@ mod tests {
         let size = 128;
         let mut mem = PolyAuxMemory::new(size / 2);
 
-        let mut inp = vec![Field32::zero(); size];
+        let inp = rand(size);
         let mut want = vec![Field32::zero(); size];
         let mut got = vec![Field32::zero(); size];
-        for i in 0..size {
-            inp[i] = Field32::rand();
-        }
 
         discrete_fourier_transform::<Field32>(&mut want, &inp, inp.len()).unwrap();
 
@@ -189,8 +183,8 @@ mod tests {
     fn test_fft_linearity() {
         let len = 16;
         let num_shares = 3;
-        let x: Vec<Field64> = rand_vec(len);
-        let mut x_shares = split(&x, num_shares);
+        let x: Vec<Field64> = rand(len);
+        let mut x_shares = split(&x, num_shares).unwrap();
 
         // Just for fun, let's do something different with a subset of the inputs. For the first
         // share, every odd element is set to the plaintext value. For all shares but the first,

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -2,6 +2,7 @@
 
 //! Finite field arithmetic for any field GF(p) for which p < 2^126.
 
+#[cfg(test)]
 use rand::{prelude::*, Rng};
 
 /// For each set of field parameters we pre-compute the 1st, 2nd, 4th, ..., 2^20-th principal roots
@@ -189,6 +190,7 @@ impl FieldParameters {
     }
 
     /// Returns a random field element mapped.
+    #[cfg(test)]
     pub fn rand_elem<R: Rng + ?Sized>(&self, rng: &mut R) -> u128 {
         let uniform = rand::distributions::Uniform::from(0..self.p);
         self.elem(uniform.sample(rng))

--- a/src/pcp/gadgets.rs
+++ b/src/pcp/gadgets.rs
@@ -407,7 +407,8 @@ where
 mod tests {
     use super::*;
 
-    use crate::field::{rand_vec, Field80 as TestField};
+    use crate::field::{rand, Field80 as TestField};
+    use crate::prng::Prng;
 
     #[test]
     fn test_mul() {
@@ -426,7 +427,7 @@ mod tests {
 
     #[test]
     fn test_poly_eval() {
-        let poly = rand_vec(10);
+        let poly = rand(10);
 
         let in_len = FFT_THRESHOLD - 1;
         let mut g: PolyEval<TestField> = PolyEval::new(poly.clone(), in_len);
@@ -454,14 +455,15 @@ mod tests {
     where
         G: Gadget<F>,
     {
+        let mut prng = Prng::new().unwrap();
         let mut inp = vec![F::zero(); g.call_in_len()];
         let mut poly_outp = vec![F::zero(); g.call_poly_out_len(in_len)];
         let mut poly_inp = vec![vec![F::zero(); in_len]; g.call_in_len()];
 
-        let r = F::rand();
+        let r = prng.next().unwrap();
         for i in 0..g.call_in_len() {
             for j in 0..in_len {
-                poly_inp[i][j] = F::rand();
+                poly_inp[i][j] = prng.next().unwrap();
             }
             inp[i] = poly_eval(&poly_inp[i], r);
         }

--- a/src/pcp/types.rs
+++ b/src/pcp/types.rs
@@ -347,7 +347,7 @@ impl<F: FieldElement> TryFrom<(usize, Vec<F>)> for MeanVarUnsignedVector<F> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::field::{rand_vec, split, Field64 as TestField};
+    use crate::field::{rand, split, Field64 as TestField};
     use crate::pcp::{decide, prove, query, Gadget, Proof, Value, Verifier};
 
     // Number of shares to split input and proofs into in `pcp_test`.
@@ -379,7 +379,7 @@ mod tests {
         // Test PCP on invalid input.
         pcp_validity_test(
             &Boolean {
-                data: vec![TestField::rand()],
+                data: vec![TestField::from(1337)],
                 range: poly_range_check(0, 2),
             },
             &ValidityTestCase {
@@ -588,8 +588,8 @@ mod tests {
     {
         let l = x.gadget(0).call_in_len();
         let rand_len = x.valid_rand_len();
-        let joint_rand = rand_vec(rand_len);
-        let query_rand = vec![F::rand()];
+        let joint_rand = rand(rand_len);
+        let query_rand = rand(1);
 
         // Ensure that `new_with` properly clones the value's parameters.
         assert_eq!(x, &V::try_from((x.param(), x.as_slice().to_vec())).unwrap());
@@ -621,6 +621,7 @@ mod tests {
 
         // Run distributed PCP.
         let x_shares: Vec<V> = split(x.as_slice(), NUM_SHARES)
+            .unwrap()
             .into_iter()
             .enumerate()
             .map(|(i, data)| {
@@ -631,6 +632,7 @@ mod tests {
             .collect();
 
         let pf_shares: Vec<Proof<F>> = split(pf.as_slice(), NUM_SHARES)
+            .unwrap()
             .into_iter()
             .map(Proof::from)
             .collect();

--- a/src/prng.rs
+++ b/src/prng.rs
@@ -67,7 +67,7 @@ impl<F: FieldElement> Prng<F> {
         let iv = GenericArray::from_slice(&seed[BLOCK_SIZE..]);
         let mut cipher = Aes128Ctr::from_block_cipher(Aes128::new(&key), &iv);
 
-        let buf_len_in_elems = std::cmp::min(length, MAXIMUM_BUFFER_SIZE_IN_ELEMENTS);
+        let buf_len_in_elems = std::cmp::min(length + 1, MAXIMUM_BUFFER_SIZE_IN_ELEMENTS);
         let mut buffer = vec![0; buf_len_in_elems * F::BYTES];
         cipher.apply_keystream(&mut buffer);
 

--- a/src/prng.rs
+++ b/src/prng.rs
@@ -6,35 +6,39 @@ use aes::{
     cipher::{generic_array::GenericArray, FromBlockCipher, NewBlockCipher, StreamCipher},
     Aes128, Aes128Ctr,
 };
-use rand::RngCore;
+use getrandom::getrandom;
 
 use std::marker::PhantomData;
 
 const BLOCK_SIZE: usize = 16;
+const DEFAULT_BUFFER_SIZE_IN_ELEMENTS: usize = 128;
 const MAXIMUM_BUFFER_SIZE_IN_ELEMENTS: usize = 4096;
 pub const SEED_LENGTH: usize = 2 * BLOCK_SIZE;
 
-pub fn secret_share<F: FieldElement>(share1: &mut [F]) -> Vec<u8> {
+pub(crate) fn secret_share<F: FieldElement>(share1: &mut [F]) -> Result<Vec<u8>, getrandom::Error> {
+    let mut seed = vec![0; SEED_LENGTH];
+    getrandom(seed.as_mut_slice())?;
+
     // get prng array
-    let (data, seed) = random_field_and_seed(share1.len());
+    let data: Vec<F> = Prng::new_with_seed_and_optional_length(&seed, Some(share1.len())).collect();
 
     // secret share
     for (s1, d) in share1.iter_mut().zip(data.iter()) {
         *s1 -= *d;
     }
 
-    seed
+    Ok(seed)
 }
 
-pub fn extract_share_from_seed<F: FieldElement>(length: usize, seed: &[u8]) -> Vec<F> {
-    random_field_from_seed(seed, length)
-}
+pub(crate) fn extract_share_from_seed<F: FieldElement>(
+    length: usize,
+    seed: &[u8],
+) -> Result<Vec<F>, PrngError> {
+    if seed.len() != 2 * BLOCK_SIZE {
+        return Err(PrngError::SeedLen);
+    }
 
-fn random_field_and_seed<F: FieldElement>(length: usize) -> (Vec<F>, Vec<u8>) {
-    let mut seed = vec![0u8; SEED_LENGTH];
-    rand::thread_rng().fill_bytes(&mut seed);
-    let data = random_field_from_seed(&seed, length);
-    (data, seed)
+    Ok(Prng::new_with_seed_and_optional_length(seed, Some(length)).collect())
 }
 
 /// Errors propagated by methods in this module.
@@ -46,39 +50,53 @@ pub(crate) enum PrngError {
 
 /// This type implements an iterator that generates a pseudorandom sequence of field elements. The
 /// sequence is derived from the key stream of AES-128 in CTR mode with a random IV.
+#[derive(Debug)]
 pub(crate) struct Prng<F: FieldElement> {
     phantom: PhantomData<F>,
     cipher: Aes128Ctr,
-    length: usize,
+    length: Option<usize>,
     buffer: Vec<u8>,
     buffer_index: usize,
     output_written: usize,
 }
 
 impl<F: FieldElement> Prng<F> {
-    /// Constructs an iterator over a pseudorandom sequence of field elements of length `length`.
-    /// `seed` is used to seed the underlying pseudorandom number generator.
-    pub(crate) fn new_with_length(seed: &[u8], length: usize) -> Result<Self, PrngError> {
-        if seed.len() != 2 * BLOCK_SIZE {
-            return Err(PrngError::SeedLen);
-        }
+    /// Generates a seed and constructs an iterator over an infinite sequence of pseudorandom field
+    /// elements.
+    pub(crate) fn new() -> Result<Self, getrandom::Error> {
+        let mut seed = [0; SEED_LENGTH];
+        getrandom(&mut seed)?;
+        Ok(Self::new_with_seed_and_optional_length(&seed, None))
+    }
 
+    /// Generates a seed and constructs an iterator over a pseudorandom sequence of field elements
+    /// of length `length`.
+    pub(crate) fn new_with_length(length: usize) -> Result<Self, getrandom::Error> {
+        let mut seed = [0; SEED_LENGTH];
+        getrandom(&mut seed)?;
+        Ok(Self::new_with_seed_and_optional_length(&seed, Some(length)))
+    }
+
+    fn new_with_seed_and_optional_length(seed: &[u8], length: Option<usize>) -> Self {
         let key = GenericArray::from_slice(&seed[..BLOCK_SIZE]);
         let iv = GenericArray::from_slice(&seed[BLOCK_SIZE..]);
         let mut cipher = Aes128Ctr::from_block_cipher(Aes128::new(&key), &iv);
 
-        let buf_len_in_elems = std::cmp::min(length + 1, MAXIMUM_BUFFER_SIZE_IN_ELEMENTS);
+        let buf_len_in_elems = match length {
+            Some(length) => std::cmp::min(length + 1, MAXIMUM_BUFFER_SIZE_IN_ELEMENTS),
+            None => DEFAULT_BUFFER_SIZE_IN_ELEMENTS,
+        };
         let mut buffer = vec![0; buf_len_in_elems * F::BYTES];
         cipher.apply_keystream(&mut buffer);
 
-        Ok(Self {
+        Self {
             phantom: PhantomData::<F>,
             cipher,
             length,
             buffer,
             buffer_index: 0,
             output_written: 0,
-        })
+        }
     }
 }
 
@@ -86,8 +104,10 @@ impl<F: FieldElement> Iterator for Prng<F> {
     type Item = F;
 
     fn next(&mut self) -> Option<F> {
-        if self.output_written >= self.length {
-            return None;
+        if let Some(length) = self.length {
+            if self.output_written >= length {
+                return None;
+            }
         }
 
         loop {
@@ -116,10 +136,6 @@ impl<F: FieldElement> Iterator for Prng<F> {
     }
 }
 
-fn random_field_from_seed<F: FieldElement>(seed: &[u8], length: usize) -> Vec<F> {
-    Prng::new_with_length(seed, length).unwrap().collect()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -132,10 +148,10 @@ mod tests {
 
         let data_clone = data.clone();
 
-        let seed = secret_share(&mut data);
+        let seed = secret_share(&mut data).unwrap();
         assert_ne!(data, data_clone);
 
-        let share2 = extract_share_from_seed(data.len(), &seed);
+        let share2 = extract_share_from_seed(data.len(), &seed).unwrap();
 
         assert_eq!(data.len(), share2.len());
 
@@ -163,7 +179,7 @@ mod tests {
             0xacb8b748, 0x6f5b9d49, 0x887d061b, 0x86db0c58,
         ];
 
-        let share2 = extract_share_from_seed::<Field32>(reference.len(), &seed);
+        let share2 = extract_share_from_seed::<Field32>(reference.len(), &seed).unwrap();
 
         assert_eq!(share2, reference);
     }
@@ -171,7 +187,7 @@ mod tests {
     /// takes a seed and hash as base64 encoded strings
     fn random_data_interop(seed_base64: &str, hash_base64: &str, len: usize) {
         let seed = base64::decode(seed_base64).unwrap();
-        let random_data = extract_share_from_seed::<Field32>(len, &seed);
+        let random_data = extract_share_from_seed::<Field32>(len, &seed).unwrap();
 
         let random_bytes = crate::util::serialize(&random_data);
 

--- a/tests/accumulating.rs
+++ b/tests/accumulating.rs
@@ -26,8 +26,8 @@ fn accumulation() {
 
     let mut reference_count = vec![0u32; dim];
 
-    let mut server1: Server<Field32> = Server::new(dim, true, priv_key1);
-    let mut server2: Server<Field32> = Server::new(dim, false, priv_key2);
+    let mut server1: Server<Field32> = Server::new(dim, true, priv_key1).unwrap();
+    let mut server2: Server<Field32> = Server::new(dim, false, priv_key2).unwrap();
 
     let mut client_mem = Client::new(dim, pub_key1, pub_key2).unwrap();
 

--- a/tests/tweaks.rs
+++ b/tests/tweaks.rs
@@ -44,8 +44,8 @@ fn tweaks(tweak: Tweak) {
     let priv_key1_clone = priv_key1.clone();
     let pub_key1_clone = pub_key1.clone();
 
-    let mut server1: Server<Field32> = Server::new(dim, true, priv_key1);
-    let mut server2: Server<Field32> = Server::new(dim, false, priv_key2);
+    let mut server1: Server<Field32> = Server::new(dim, true, priv_key1).unwrap();
+    let mut server2: Server<Field32> = Server::new(dim, false, priv_key2).unwrap();
 
     let mut client_mem = Client::new(dim, pub_key1, pub_key2).unwrap();
 


### PR DESCRIPTION
We currently use rand=0.7.3. Support for WASM was dropped in rand=0.8, so users won't be able to compile libprio-rs if we upgrade this dependency: see https://github.com/rust-random/rand/blob/HEAD/CHANGELOG.md#080---2020-12-18.
    
This change aims to nip this problem in the bud by dropping the rand dependency and replacing it with getrandom, which will support WASM in the future.