### PR TITLE
Support for multiple gadgets

### DIFF
--- a/src/pcp/types.rs
+++ b/src/pcp/types.rs
@@ -604,6 +604,7 @@ mod tests {
         G: Gadget<F>,
         V: Value<F, G>,
     {
+        // XXX This test won't work if x.gadget().len() > 1.
         let l = x.gadget().arity(0);
         let rand_len = x.valid_rand_len();
         let joint_rand = rand(rand_len).unwrap();


### PR DESCRIPTION
[Not ready for review.] Changes in this PR:

- Change `GadgetCallOnly` and `Gadget` to expose an `idx` parameter. This allows gadgets to be implemented that are comprised of many "sub-gadgets". (`idx==0` dispatches the first gadget; `idx==1` dispatches the second gadget; and so on.)
- Extend `prove`, `query`, and `decide` to support validity circuits with multiple gadgets.
- Change `Value::valid_gadget_calls()` to take an `idx` parameter.
- Simplify `Value::gadget()` by removing the length hint. This will be computed by the instance of `Value`.