### PR TITLE
Add support for multiple gadgets

### DIFF
--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -49,8 +49,8 @@ pub fn prng(c: &mut Criterion) {
 pub fn poly_mul(c: &mut Criterion) {
     let test_sizes = [1_usize, 30, 60, 90, 120, 150];
     for size in test_sizes.iter() {
-        let m = size.next_power_of_two();
-        let mut g: Mul<F> = Mul::new(m);
+        let m = (*size + 1).next_power_of_two();
+        let mut g: Mul<F> = Mul::new(*size);
         let mut outp = vec![F::zero(); 2 * m];
         let mut inp = vec![vec![]; 2];
         for i in 0..2 {
@@ -140,7 +140,7 @@ pub fn bool_vec(c: &mut Criterion) {
 /// Benchmark proof generation and verification for the MeanVarUnsignedVector type.
 pub fn mean_var_int_vec(c: &mut Criterion) {
     let bits = 12;
-    let test_sizes = [1, 10, 20, 100, 1_000, 10_000];
+    let test_sizes = [1, 10, 20, 100, 1_000];
     for size in test_sizes.iter() {
         let data = vec![0; *size];
 

--- a/src/benchmarked.rs
+++ b/src/benchmarked.rs
@@ -30,20 +30,20 @@ pub fn benchmarked_recursive_fft<F: FieldElement>(outp: &mut [F], inp: &[F]) {
 
 /// Sets `outp` to `inp[0] * inp[1]`, where `inp[0]` and `inp[1]` are polynomials. This function
 /// uses FFT for multiplication.
-pub fn benchmarked_gadget_mul_call_poly_fft<F: FieldElement, V: AsRef<[F]>>(
+pub fn benchmarked_gadget_mul_call_poly_fft<F: FieldElement>(
     g: &mut Mul<F>,
     outp: &mut [F],
-    inp: &[V],
+    inp: &Vec<Vec<F>>,
 ) -> Result<(), PcpError> {
     g.call_poly_fft(outp, inp)
 }
 
 /// Sets `outp` to `inp[0] * inp[1]`, where `inp[0]` and `inp[1]` are polynomials. This function
 /// does the multiplication directly.
-pub fn benchmarked_gadget_mul_call_poly_direct<F: FieldElement, V: AsRef<[F]>>(
+pub fn benchmarked_gadget_mul_call_poly_direct<F: FieldElement>(
     g: &mut Mul<F>,
     outp: &mut [F],
-    inp: &[V],
+    inp: &Vec<Vec<F>>,
 ) -> Result<(), PcpError> {
     g.call_poly_direct(outp, inp)
 }

--- a/src/field.rs
+++ b/src/field.rs
@@ -48,6 +48,7 @@ pub trait FieldElement:
     + Neg<Output = Self>
     + Display
     + From<<Self as FieldElement>::Integer>
+    + 'static // NOTE This bound is needed for downcasting a `dyn Gadget<F>>` to a concrete type.
 {
     /// Size of each field element in bytes.
     const BYTES: usize;

--- a/src/pcp.rs
+++ b/src/pcp.rs
@@ -1,39 +1,41 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! **(NOTE: This module is experimental. Applications should not use it yet.)** This
-//! module implements the fully linear PCP ("Probabilistically Checkable Proof") system described
-//! in \[[BBC+19](https://eprint.iacr.org/2019/188), Theorem 4.3\].
+//! **(NOTE: This module is experimental. Applications should not use it yet.)** This module
+//! implements a fully linear PCP ("Probabilistically Checkable Proof") system based on
+//! \[[BBC+19](https://eprint.iacr.org/2019/188), Theorem 4.3\].
 //!
 //! # Overview
 //!
 //! The proof system is comprised of three algorithms. The first, `prove`, is run by the prover in
 //! order to generate a proof of a statement's validity. The second and third, `query` and
-//! `decide`, are run by the verifier in order to check the proof. In our setting, the proof
-//! asserts that the prover's is a valid encoding of a value of a given type. For example:
+//! `decide`, are run by the verifier in order to check the proof. The proof asserts that the input
+//! is an element of a language recognized by an arithmetic circuit. For example:
 //!
 //! ```
 //! use prio::pcp::types::Boolean;
-//! use prio::pcp::{decide, prove, query};
+//! use prio::pcp::{decide, prove, query, Value};
 //! use prio::field::{rand, FieldElement, Field64};
 //!
-//! // The randomness shared by the prover and verifier. In proof systems like [BCG+19, Theorem
-//! // 5.3], the verifier sends the prover a random challenge in the first round, which the
-//! // prover uses to construct the proof. (This is not used for this example, so `joint_rand'
-//! // is empty.)
-//! let joint_rand = [];
-//!
-//! // The randomness used by the verifier.
-//! let query_rand = rand(1).unwrap();
-//!
-//! // The prover generates a proof pf that its input x is a valid encoding
-//! // of a boolean (either "true" or "false"). Both the input and proof are
-//! // vectors over the finite field specified by Field64.
+//! // The prover generates a proof `pf` that its input `x` is a valid encoding
+//! // of a boolean (either `true` or `false`). Both the input and proof are
+//! // vectors over a finite field.
 //! let x: Boolean<Field64> = Boolean::new(false);
+//!
+//! // The verifier chooses "joint randomness" that that will be used to
+//! // generate and verify a proof of `x`'s validity. In proof systems like
+//! // [BBC+19, Theorem 5.3], the verifier sends the prover a random challenge
+//! // in the first round, which the prover uses to construct the proof.
+//! let joint_rand = rand(x.valid_rand_len()).unwrap();
+//!
+//! // The verifier chooses local randomness it uses to check the proof.
+//! let query_rand = rand(x.valid_gadget_len()).unwrap();
+//!
+//! // The prover generates the proof.
 //! let pf = prove(&x, &joint_rand).unwrap();
 //!
-//! // The verifier "queries" the proof pf and input x, getting a "verification
-//! // message" in response. It uses this message to decide if the input is
-//! // valid.
+//! // The verifier queries the proof `pf` and input `x`, getting a
+//! // "verification message" in response. It uses this message to decide if
+//! // the input is valid.
 //! let vf = query(&x, &pf, &query_rand, &joint_rand).unwrap();
 //! let res = decide(&x, &vf).unwrap();
 //! assert_eq!(res, true);
@@ -46,9 +48,11 @@
 //! use prio::pcp::{decide, prove, query, Value};
 //! use prio::field::{rand, FieldElement, Field64};
 //!
-//! let joint_rand = [];
-//! let query_rand = rand(1).unwrap();
-//! let x = Boolean::from(Field64::from(23));
+//! use std::convert::TryFrom;
+//!
+//! let x = Boolean::try_from(((), vec![Field64::from(23)])).unwrap(); // Invalid input
+//! let joint_rand = rand(x.valid_rand_len()).unwrap();
+//! let query_rand = rand(x.valid_gadget_len()).unwrap();
 //! let pf = prove(&x, &joint_rand).unwrap();
 //! let vf = query(&x, &pf, &query_rand, &joint_rand).unwrap();
 //! let res = decide(&x, &vf).unwrap();
@@ -69,9 +73,6 @@
 //!
 //! use std::convert::TryFrom;
 //!
-//! let joint_rand = [];
-//! let query_rand = rand(1).unwrap();
-//!
 //! // The prover encodes its input and splits it into two secret shares. It
 //! // sends each share to two aggregators.
 //! let x: Boolean<Field64>= Boolean::new(true);
@@ -81,6 +82,9 @@
 //!     .into_iter()
 //!     .map(|data| Boolean::try_from((x_par, data)).unwrap())
 //!     .collect();
+//!
+//! let joint_rand = rand(x.valid_rand_len()).unwrap();
+//! let query_rand = rand(x.valid_gadget_len()).unwrap();
 //!
 //! // The prover generates a proof of its input's validity and splits the proof
 //! // into two shares. It sends each share to one of two aggregators.
@@ -111,9 +115,6 @@
 //! multiplication). For example, the `Boolean` type uses the `Mul` gadget, an arity-2 circuit that
 //! simply multiples its inputs and outputs the result.
 //!
-//! A concrete system is instantiated by implementing the `Value` trait. This includes specifying
-//! the validity circuit, as well as the underlying gadget (the `Gadget` trait).
-//!
 //! # References
 //!
 //! - \[GB17\] H. Corrigan-Gibbs and D. Boneh. "[Prio: Private, Robust, and Scalable Computation of
@@ -121,19 +122,20 @@
 //! - \[BBC+19\] Boneh et al. "[Zero-Knowledge Proofs on Secret-Shared Data via Fully Linear
 //! PCPs.](https://eprint.iacr.org/2019/188)" CRYPTO 2019.
 
+use std::any::Any;
 use std::convert::TryFrom;
 use std::fmt::Debug;
 
 use crate::fft::{discrete_fourier_transform, discrete_fourier_transform_inv_finish, FftError};
 use crate::field::{FieldElement, FieldError};
 use crate::fp::log2;
-use crate::polynomial::{poly_deg, poly_eval};
+use crate::polynomial::poly_eval;
 use crate::prng::Prng;
 
 pub mod gadgets;
 pub mod types;
 
-/// Errors propagagted by methods in this module.
+/// Errors propagated by methods in this module.
 #[derive(Debug, PartialEq, thiserror::Error)]
 pub enum PcpError {
     /// The caller of an arithmetic circuit provided the wrong number of inputs. This error may
@@ -195,40 +197,34 @@ pub enum PcpError {
 
 /// A value of a certain type. Implementations of this trait specify an arithmetic circuit that
 /// determines whether a given value is valid.
-pub trait Value<F, G>:
+pub trait Value<F: FieldElement>:
     Sized
     + PartialEq
     + Eq
     + Debug
-    + TryFrom<(<Self as Value<F, G>>::Param, Vec<F>), Error = <Self as Value<F, G>>::TryFromError>
-where
-    F: FieldElement,
-    G: Gadget<F>,
+    + TryFrom<(<Self as Value<F>>::Param, Vec<F>), Error = <Self as Value<F>>::TryFromError>
 {
     /// Parameters used to construct a value of this type from a vector of field elements.
     type Param;
 
-    /// Error returned when converting a `(Vec<F>, Param)` to a `Value<F, G>` fails.
+    /// Error returned when converting a `(Param, Vec<F>)` to a `Value<F>` fails.
     type TryFromError: Debug;
 
     /// Evaluates the validity circuit on the given input (i.e., `self`) and returns the output.
-    /// Slice `rand` is the random input consumed by the validity circuit.
+    /// `joint_rand` is the joint randomness shared by the prover and verifier. `g` is the sequence
+    /// of gadgets called by the circuit.
     ///
     /// ```
     /// use prio::pcp::types::Boolean;
     /// use prio::pcp::Value;
     /// use prio::field::{rand, FieldElement, Field64};
     ///
-    /// type F = Field64;
-    /// type T = Boolean<F>;
-    ///
-    /// let x = T::new(false);
-    ///
+    /// let x: Boolean<Field64> = Boolean::new(false);
     /// let joint_rand = rand(x.valid_rand_len()).unwrap();
-    /// let v = x.valid(&mut x.gadget(0), &joint_rand).unwrap();
-    /// assert_eq!(v, F::zero());
+    /// let v = x.valid(&mut x.gadget(), &joint_rand).unwrap();
+    /// assert_eq!(v, Field64::zero());
     /// ```
-    fn valid(&self, g: &mut dyn GadgetCallOnly<F>, rand: &[F]) -> Result<F, PcpError>;
+    fn valid(&self, g: &mut Vec<Box<dyn Gadget<F>>>, joint_rand: &[F]) -> Result<F, PcpError>;
 
     /// Returns a reference to the underlying data.
     fn as_slice(&self) -> &[F];
@@ -236,13 +232,23 @@ where
     /// The length of the random input expected by the validity circuit.
     fn valid_rand_len(&self) -> usize;
 
-    /// The number of calls to the gadget made when evaluating the validity circuit.
-    fn valid_gadget_calls(&self) -> usize;
+    /// The number of gadgets expected by the validity circuit.
+    fn valid_gadget_len(&self) -> usize;
 
-    /// Returns an instance of the gadget associated with the validity circuit. `in_len` is the
-    /// maximum degree of each of the polynomials passed into `call_poly`. If `call_poly` is never
-    /// used by the caller, then it is safe to set `in_len == 0`.
-    fn gadget(&self, in_len: usize) -> G;
+    /// The number of calls to the gadget made when evaluating the validity circuit.
+    ///
+    /// TODO(cjpatton) Consider consolidating this and `gadget` into one call. The benefit would be
+    /// that there is one less thing to worry about when implementing a Value<F>. We would need to
+    /// extend Gadget<F> so that it tells you how many times it gets called.
+    fn valid_gadget_calls(&self) -> Vec<usize>;
+
+    /// Returns the sequence of gadgets associated with the validity circuit.
+    ///
+    /// NOTE The construction of [BBC+19, Theorem 4.3] uses a single gadget rather than many. The
+    /// idea to generalize the proof system to allow multiple gadgets is discussed briefly in
+    /// [BBC+19, Remark 4.5], but no construction is given. The construction implemented here
+    /// requires security analysis.
+    fn gadget(&self) -> Vec<Box<dyn Gadget<F>>>;
 
     /// Returns a copy of the associated type parameters for this value.
     fn param(&self) -> Self::Param;
@@ -260,10 +266,6 @@ where
     ///
     /// let measurement = [1, 2, 3];
     /// let bits = 8;
-    ///
-    /// let joint_rand = rand(3).unwrap();
-    /// let query_rand = rand(1).unwrap();
-    ///
     /// let x: MeanVarUnsignedVector<Field64> =
     ///     MeanVarUnsignedVector::new(bits, &measurement).unwrap();
     /// let x_shares: Vec<MeanVarUnsignedVector<Field64>> = split(x.as_slice(), 2)
@@ -277,6 +279,9 @@ where
     ///         share
     ///     })
     ///     .collect();
+    ///
+    /// let joint_rand = rand(x.valid_rand_len()).unwrap();
+    /// let query_rand = rand(x.valid_gadget_len()).unwrap();
     ///
     /// let pf = prove(&x, &joint_rand).unwrap();
     /// let pf_shares: Vec<Proof<Field64>> = split(pf.as_slice(), 2)
@@ -299,114 +304,150 @@ where
     }
 }
 
-/// The gadget functionality required for evaluating a validity circuit. The `Gadget` trait
-/// inherits this trait.
-pub trait GadgetCallOnly<F: FieldElement> {
+/// A gadget, a non-affine arithmetic circuit that is called when evaluating a validity circuit.
+///
+/// TODO(cjpatton) Consider extending this API with a `Param` associated type and have it implement
+/// a constructor from an instance of `Param` and the number of times the gadget gets called.
+pub trait Gadget<F: FieldElement> {
     /// Evaluates the gadget on input `inp` and returns the output.
     fn call(&mut self, inp: &[F]) -> Result<F, PcpError>;
 
-    /// Returns the circuit's arity, i.e., the expected length of the input to `call`.
-    fn call_in_len(&self) -> usize;
-}
-
-/// The sub-circuit associated with some validity circuit. A gadget is called either on a sequence
-/// of finite field elements or a sequence of polynomials over a finite field.
-pub trait Gadget<F: FieldElement>: GadgetCallOnly<F> {
     /// Evaluate the gadget on input of a sequence of polynomials. The output is written to `outp`.
-    fn call_poly<V: AsRef<[F]>>(&mut self, outp: &mut [F], inp: &[V]) -> Result<(), PcpError>;
+    fn call_poly(&mut self, outp: &mut [F], inp: &Vec<Vec<F>>) -> Result<(), PcpError>;
 
-    /// The maximum degree of the polynomial output by `call_poly` as a function of the maximum
-    /// degree of each input polynomial.
-    fn call_poly_out_len(&self, in_len: usize) -> usize;
+    /// Returns the arity of the gadget. This is the length of `inp` passed to `call` or
+    /// `call_poly`.
+    fn arity(&self) -> usize;
+
+    /// Returns the circuit's arithmetic degree. This determines the minimum length the `outp`
+    /// buffer passed to `call_poly`.
+    fn deg(&self) -> usize;
+
+    /// This call is used to downcast a `Box<dyn Gadget<F>>` to a concrete type.
+    fn as_any(&mut self) -> &mut dyn Any;
 }
 
 /// Generate a proof of an input's validity.
-pub fn prove<F, G, V>(x: &V, joint_rand: &[F]) -> Result<Proof<F>, PcpError>
+pub fn prove<F, V>(x: &V, joint_rand: &[F]) -> Result<Proof<F>, PcpError>
 where
     F: FieldElement,
-    G: Gadget<F>,
-    V: Value<F, G>,
+    V: Value<F>,
 {
     let g_calls = x.valid_gadget_calls();
-    let m = (g_calls + 1).next_power_of_two();
-    let mut g = x.gadget(m);
-    let p = g.call_poly_out_len(m);
-    let l = g.call_in_len();
-    let mut data = vec![F::zero(); l + p];
 
-    // Run the validity circuit with a "shim" gadget that records the value of each input wire of
-    // each gadget evaluation.
-    let mut shim = ProveShimGadget::new(&mut g, g_calls)?;
+    let mut shim = x
+        .gadget()
+        .into_iter()
+        .enumerate()
+        .map(|(idx, g)| ProveShimGadget::new(g, g_calls[idx]))
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Create a buffer for storing the proof. The buffer is longer than the proof itself; the extra
+    // length is to accommodate the computation of each of the proof polynomials.
+    let data_len = (0..shim.len())
+        .map(|idx| shim[idx].arity() + shim[idx].deg() * (1 + g_calls[idx]).next_power_of_two())
+        .sum();
+    let mut data = vec![F::zero(); data_len];
+
+    // Run the validity circuit with a sequence of "shim" gadgets that record the value of each
+    // input wire of each gadget evaluation. These values are used to construct the intermediate
+    // proof polynomials in the next step.
     let _ = x.valid(&mut shim, joint_rand);
 
-    // Construct the intermediate proof polynomials `f[0], ..., f[l-1]`. Also, record in the slice
-    // `data[..l]` the value of `f[i](1)`, i.e., the first point at which polynomial `f[i]` was
-    // interpolated.
-    let mut f = vec![vec![F::zero(); m]; l];
-    let m_inv = F::from(F::Integer::try_from(m).unwrap()).inv();
-    for i in 0..l {
-        data[i] = shim.f_vals[i][0];
-        discrete_fourier_transform(&mut f[i], &shim.f_vals[i], m)?;
-        discrete_fourier_transform_inv_finish(&mut f[i], m, m_inv);
+    // Fill the buffer with the proof. `proof_len` keeps track of the amount of data written to the
+    // buffer so far.
+    let mut proof_len = 0;
+    for idx in 0..shim.len() {
+        let g = shim[idx]
+            .as_any()
+            .downcast_mut::<ProveShimGadget<F>>()
+            .unwrap();
+
+        let g_deg = g.deg();
+        let g_arity = g.arity();
+
+        // Interpolate the intermediate proof polynomials `f[0], ..., f[g_arity-1]` from the gadget
+        // inputs.
+        let m = (1 + g_calls[idx]).next_power_of_two();
+        let m_inv = F::from(F::Integer::try_from(m).unwrap()).inv();
+        let mut f = vec![vec![F::zero(); m]; g_arity];
+        for wire in 0..g_arity {
+            discrete_fourier_transform(&mut f[wire], &g.f_vals[wire], m)?;
+            discrete_fourier_transform_inv_finish(&mut f[wire], m, m_inv);
+
+            // The first point on each intermediate polynomial is a random value chosen by the
+            // prover. This point is stored in the proof so that the verifier can reconstruct the
+            // polynomial.
+            data[proof_len + wire] = g.f_vals[wire][0];
+        }
+
+        // Construct the proof polynomial `G(f[0], ..., f[g_arity-1])` and append it to `data`.
+        g.call_poly(&mut data[proof_len + g_arity..], &f)?;
+        proof_len += g_arity + g_deg * (m - 1) + 1;
     }
 
-    // Construct the proof polynomial `data[l..] = G(f[0], ..., f[l-1])`.
-    g.call_poly(&mut data[l..], &f)?;
-
-    let poly_len = poly_deg(&data[l..]);
-    data.truncate(l + poly_len + 1);
+    // Truncate the buffer to the size of the proof.
+    data.truncate(proof_len);
     Ok(Proof { data })
 }
 
 // A "shim" gadget used during proof generation to record the points at which the intermediate
 // proof polynomials are interpolated.
-struct ProveShimGadget<'a, F, G>
-where
-    F: FieldElement,
-    G: Gadget<F>,
-{
-    inner: &'a mut G,
+struct ProveShimGadget<F: FieldElement> {
+    inner: Box<dyn Gadget<F>>,
+
     /// Points at which intermediate proof polynomials are interpolated.
     f_vals: Vec<Vec<F>>,
+
     /// The number of times the gadget has been called so far.
     ct: usize,
 }
 
-impl<'a, F, G> ProveShimGadget<'a, F, G>
-where
-    F: FieldElement,
-    G: Gadget<F>,
-{
-    fn new(inner: &'a mut G, gadget_calls: usize) -> Result<Self, getrandom::Error> {
-        let mut f_vals = vec![vec![F::zero(); gadget_calls + 1]; inner.call_in_len()];
+impl<F: FieldElement> ProveShimGadget<F> {
+    fn new(
+        inner: Box<dyn Gadget<F>>,
+        g_calls: usize,
+    ) -> Result<Box<dyn Gadget<F>>, getrandom::Error> {
+        let mut f_vals = vec![vec![F::zero(); 1 + g_calls]; inner.arity()];
         let mut prng = Prng::new_with_length(f_vals.len())?;
-        for i in 0..f_vals.len() {
-            // Choose a random field element as first point on the i-th proof polynomial.
-            f_vals[i][0] = prng.next().unwrap();
+
+        for wire in 0..f_vals.len() {
+            // Choose a random field element as the first point on the intermediate proof
+            // polynomial.
+            f_vals[wire][0] = prng.next().unwrap();
         }
-        Ok(Self {
+
+        Ok(Box::new(Self {
             inner,
             f_vals,
             ct: 1,
-        })
+        }))
     }
 }
 
-impl<'a, F, G> GadgetCallOnly<F> for ProveShimGadget<'a, F, G>
-where
-    F: FieldElement,
-    G: Gadget<F>,
-{
+impl<F: FieldElement> Gadget<F> for ProveShimGadget<F> {
     fn call(&mut self, inp: &[F]) -> Result<F, PcpError> {
-        for i in 0..inp.len() {
-            self.f_vals[i][self.ct] = inp[i];
+        for wire in 0..inp.len() {
+            self.f_vals[wire][self.ct] = inp[wire];
         }
         self.ct += 1;
         self.inner.call(inp)
     }
 
-    fn call_in_len(&self) -> usize {
-        self.inner.call_in_len()
+    fn call_poly(&mut self, outp: &mut [F], inp: &Vec<Vec<F>>) -> Result<(), PcpError> {
+        self.inner.call_poly(outp, inp)
+    }
+
+    fn arity(&self) -> usize {
+        self.inner.arity()
+    }
+
+    fn deg(&self) -> usize {
+        self.inner.deg()
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
     }
 }
 
@@ -429,15 +470,15 @@ impl<F: FieldElement> From<Vec<F>> for Proof<F> {
     }
 }
 
-/// Generate the verifier for an input and proof (or the verifier share for an input share and
-/// proof share).
+/// Generate a verifier message for an input and proof (or the verifier share for an input share
+/// and proof share).
 ///
 /// Parameters:
 /// * `x` is the input.
 /// * `pf` is the proof.
 /// * `query_rand` is the verifier's randomness.
 /// * `joint_rand` is the randomness shared by the prover and verifier.
-pub fn query<F, G, V>(
+pub fn query<F, V>(
     x: &V,
     pf: &Proof<F>,
     query_rand: &[F],
@@ -445,150 +486,201 @@ pub fn query<F, G, V>(
 ) -> Result<Verifier<F>, PcpError>
 where
     F: FieldElement,
-    G: Gadget<F>,
-    V: Value<F, G>,
+    V: Value<F>,
 {
-    if query_rand.len() != 1 {
-        return Err(PcpError::Query("incorrect length of verifier randomness"));
+    let g_calls = x.valid_gadget_calls();
+
+    let mut proof_len = 0;
+    let mut shim = x
+        .gadget()
+        .into_iter()
+        .enumerate()
+        .map(|(idx, g)| {
+            if idx >= query_rand.len() {
+                return Err(PcpError::Query("short query randomness"));
+            }
+
+            let g_deg = g.deg();
+            let g_arity = g.arity();
+            let m = (1 + g_calls[idx]).next_power_of_two();
+
+            // Compute the length of the sub-proof corresponding to the `idx`-th gadget.
+            let next_len = g_arity + g_deg * (m - 1) + 1;
+            if proof_len + next_len > pf.data.len() {
+                return Err(PcpError::Query("short proof"));
+            }
+
+            let proof_data = &pf.data[proof_len..proof_len + next_len];
+            proof_len += next_len;
+
+            QueryShimGadget::new(g, query_rand[idx], proof_data, g_calls[idx])
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    if proof_len < pf.data.len() {
+        return Err(PcpError::Query("long proof"));
     }
 
-    let g_calls = x.valid_gadget_calls();
-    let m = (g_calls + 1).next_power_of_two();
-    let g = x.gadget(m);
-    let l = g.call_in_len();
+    if query_rand.len() > shim.len() {
+        return Err(PcpError::Query("long joint randomness"));
+    }
 
-    // Allocate space for the verifier data. This includes the output of the validity circuit, the
-    // intermediate polynomials evaluated at the query randomness `r`, and the proof polynomial
-    // evaluated at `r`.
-    let mut verifier_data = Vec::with_capacity(2 + l);
+    // Create a buffer for the verifier data. This includes the output of the validity circuit as
+    // well as the intermediate polynomials evaluated at the query randomness `query_rand[idx]`,
+    // and the proof polynomial evaluated at `query_rand[idx]` for the `idx`-th gadget.
+    let data_len = 1
+        + (0..shim.len())
+            .map(|idx| shim[idx].arity() + 1)
+            .sum::<usize>();
+    let mut data = Vec::with_capacity(data_len);
 
-    // Run the validity circuit with a "shim" gadget that records each input to each gadget.
-    // Record the output of the circuit.
+    // Run the validity circuit with a sequence of "shim" gadgets that record the inputs to each
+    // wire for each gadget call. Record the output of the circuit and append it to the verifier
+    // message.
     //
     // NOTE The proof of [BBC+19, Theorem 4.3] assumes that the output of the validity circuit is
     // equal to the output of the last gadget evaluation. Here we relax this assumption. This
     // should be OK, since it's possible to transform any circuit into one for which this is true.
     // (Needs security analysis.)
-    let mut shim = QueryShimGadget::new(&g, g_calls, pf)?;
-    verifier_data.push(x.valid(&mut shim, joint_rand)?);
+    let v = x.valid(&mut shim, joint_rand)?;
+    data.push(v);
 
-    // Reconstruct the intermediate proof polynomials `f[0], ..., f[l-1]` and evaluate each
-    // polynomial at input `r`.
-    let mut f = vec![F::zero(); m];
-    let m_inv = F::from(F::Integer::try_from(m).unwrap()).inv();
-    for i in 0..l {
-        discrete_fourier_transform(&mut f, &shim.f_vals[i], m)?;
-        discrete_fourier_transform_inv_finish(&mut f, m, m_inv);
-        verifier_data.push(poly_eval(&f, query_rand[0]));
+    // Fill the buffer with the verifier message.
+    for idx in 0..shim.len() {
+        let r = query_rand[idx];
+        let g = shim[idx]
+            .as_any()
+            .downcast_ref::<QueryShimGadget<F>>()
+            .unwrap();
+
+        // Reconstruct the intermediate proof polynomials `f[0], ..., f[g_arity-1]` and evaluate
+        // each polynomial at input `r`.
+        let m = (1 + g_calls[idx]).next_power_of_two();
+        let m_inv = F::from(F::Integer::try_from(m).unwrap()).inv();
+        let mut f = vec![F::zero(); m];
+        for wire in 0..g.arity() {
+            discrete_fourier_transform(&mut f, &g.f_vals[wire], m)?;
+            discrete_fourier_transform_inv_finish(&mut f, m, m_inv);
+            data.push(poly_eval(&f, r));
+        }
+
+        // Add the value of the proof polynomial evaluated at `r`.
+        data.push(g.p_at_r);
     }
 
-    // Evaluate the proof polynomial `p` at `r`.
-    //
-    // NOTE Usually `r` is sampled uniformly from the field. Strictly speaking, [BBC+19, Theorem
-    // 4.3] requires that `r` be sampled from the set of field elements *minus* the roots of unity
-    // at which the polynomials are interpolated. This relaxation is fine, but results in a
-    // modest loss of concrete security. (Needs security analysis.)
-    verifier_data.push(poly_eval(&pf.data[l..], query_rand[0]));
-
-    Ok(Verifier {
-        data: verifier_data,
-    })
+    Ok(Verifier { data })
 }
 
 // A "shim" gadget used during proof verification to record the points at which the intermediate
 // proof polynomials are evaluated.
 struct QueryShimGadget<F: FieldElement> {
+    inner: Box<dyn Gadget<F>>,
+
     /// Points at which intermediate proof polynomials are interpolated.
     f_vals: Vec<Vec<F>>,
+
     /// Points at which the proof polynomial is interpolated.
     p_vals: Vec<F>,
+
+    /// The proof polynomial evaluated on a random input `r`.
+    p_at_r: F,
+
     /// Used to compute an index into `p_val`.
     step: usize,
+
     /// The number of times the gadget has been called so far.
     ct: usize,
-    /// The arity of the inner gadget.
-    l: usize,
 }
 
 impl<F: FieldElement> QueryShimGadget<F> {
-    fn new<G: Gadget<F>>(inner: &G, g_calls: usize, pf: &Proof<F>) -> Result<Self, PcpError> {
-        let m = (g_calls + 1).next_power_of_two();
-        let p = inner.call_poly_out_len(m);
-        let l = inner.call_in_len();
+    fn new(
+        inner: Box<dyn Gadget<F>>,
+        r: F,
+        proof_data: &[F],
+        g_calls: usize,
+    ) -> Result<Box<dyn Gadget<F>>, PcpError> {
+        let g_deg = inner.deg();
+        let g_arity = inner.arity();
+        let m = (1 + g_calls).next_power_of_two();
+        let p = m * g_deg;
 
-        if pf.data.len() < l || pf.data.len() > l + p {
-            return Err(PcpError::Query("incorrect proof length"));
-        }
-
-        // Record the intermediate polynomial seeds.
-        let mut f_vals = vec![vec![F::zero(); g_calls + 1]; l];
-        for i in 0..l {
-            f_vals[i][0] = pf.data[i]
+        // Each call to this gadget records the values at which intermediate proof polynomials were
+        // interpolated. The first point was a random value chosen by the prover and transmitted in
+        // the proof.
+        let mut f_vals = vec![vec![F::zero(); 1 + g_calls]; g_arity];
+        for wire in 0..g_arity {
+            f_vals[wire][0] = proof_data[wire];
         }
 
         // Evaluate the proof polynomial at roots of unity.
         let size = p.next_power_of_two();
         let mut p_vals = vec![F::zero(); size];
-        discrete_fourier_transform(&mut p_vals, &pf.data[l..], size)?;
+        discrete_fourier_transform(&mut p_vals, &proof_data[g_arity..], size)?;
 
+        // The step is used to compute the element of `p_val` that will be returned by a call to
+        // the gadget.
         let step = (1 << (log2(p as u128) - log2(m as u128))) as usize;
-        Ok(QueryShimGadget {
+
+        // Evaluate the proof polynomial `p` at `r`.
+        //
+        // NOTE Usually `r` is sampled uniformly from the field. Strictly speaking, [BBC+19, Theorem
+        // 4.3] requires that `r` be sampled from the set of field elements *minus* the roots of unity
+        // at which the polynomials are interpolated. This relaxation is fine, but results in a
+        // modest loss of concrete security. (Needs security analysis.)
+        let p_at_r = poly_eval(&proof_data[g_arity..], r);
+
+        Ok(Box::new(QueryShimGadget {
+            inner,
             f_vals,
             p_vals,
+            p_at_r,
             step,
             ct: 1,
-            l,
-        })
+        }))
     }
 }
 
-impl<F: FieldElement> GadgetCallOnly<F> for QueryShimGadget<F> {
+impl<F: FieldElement> Gadget<F> for QueryShimGadget<F> {
     fn call(&mut self, inp: &[F]) -> Result<F, PcpError> {
-        for i in 0..inp.len() {
-            self.f_vals[i][self.ct] = inp[i];
+        for wire in 0..inp.len() {
+            self.f_vals[wire][self.ct] = inp[wire];
         }
         let outp = self.p_vals[self.ct * self.step];
         self.ct += 1;
         Ok(outp)
     }
 
-    fn call_in_len(&self) -> usize {
-        self.l
+    fn call_poly(&mut self, _outp: &mut [F], _inp: &Vec<Vec<F>>) -> Result<(), PcpError> {
+        panic!("no-op");
+    }
+
+    fn arity(&self) -> usize {
+        self.inner.arity()
+    }
+
+    fn deg(&self) -> usize {
+        self.inner.deg()
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
     }
 }
 
 /// The output of `query`, the verifier message generated for a proof.
 #[derive(Debug)]
 pub struct Verifier<F: FieldElement> {
-    /// `data` consists of the following values:
-    ///
-    ///  * `data[0]` is the output of the validity circuit;
-    ///  * `data[1..l+1]` are the outputs of the intermediate proof polynomials evaluated at the
-    ///     query randomness `r` (`l` denotes the arity of the gadget); and
-    ///  * `data[l+1]` is the output of the proof polynomial evaluated at `r`.
     data: Vec<F>,
 }
 
 impl<F: FieldElement> Verifier<F> {
-    /// Returns a reference to the underlying data.
+    /// Returns a reference to the underlying data. The first element of the output is the output
+    /// of the validity circuit. The remainder is a sequence of chunks, where the `idx`-th chunk
+    /// corresponds to the `idx`-th gadget for the validity circuit. The last element of a chunk is
+    /// the proof polynomial evaluated on a random input `r`; the rest are the intermediate proof
+    /// polynomials evaluated at `r`.
     pub fn as_slice(&self) -> &[F] {
         &self.data
-    }
-
-    /// Returns the output of the validity circuit.
-    fn validity(&self) -> F {
-        self.data[0]
-    }
-
-    /// Returns the outputs of the intermediate proof polynomials evaluated at the query
-    /// randomness.
-    fn f_at_r(&self) -> &[F] {
-        &self.data[1..self.data.len() - 1]
-    }
-
-    /// Returns the output of the proof polynomial evaluated at the query randomness.
-    fn p_at_r(&self) -> F {
-        self.data[self.data.len() - 1]
     }
 }
 
@@ -626,65 +718,92 @@ impl<F: FieldElement> TryFrom<&[Verifier<F>]> for Verifier<F> {
 }
 
 /// Decide if the input (or input share) is valid using the given verifier.
-pub fn decide<F, G, V>(x: &V, vf: &Verifier<F>) -> Result<bool, PcpError>
+pub fn decide<F, V>(x: &V, vf: &Verifier<F>) -> Result<bool, PcpError>
 where
     F: FieldElement,
-    G: Gadget<F>,
-    V: Value<F, G>,
+    V: Value<F>,
 {
-    let mut g = x.gadget(0);
-    let vf_len = vf.data.len();
-    if vf_len < 2 + g.call_in_len() {
-        return Err(PcpError::Decide("short verifier message"));
+    let mut g = x.gadget();
+
+    if vf.data.len() == 0 {
+        return Err(PcpError::Decide("zero-length verifier"));
     }
 
-    let e = g.call(vf.f_at_r())?;
-    if e == vf.p_at_r() && vf.validity() == F::zero() {
-        Ok(true)
-    } else {
-        Ok(false)
+    // Check if the output of the circuit is 0.
+    if vf.data[0] != F::zero() {
+        return Ok(false);
     }
+
+    // Check that each of the proof polynomials are well-formed.
+    let mut verifier_len = 1;
+    for idx in 0..g.len() {
+        let next_len = 1 + g[idx].arity();
+        if verifier_len + next_len > vf.data.len() {
+            return Err(PcpError::Decide("short verifier"));
+        }
+
+        let e = g[idx].call(&vf.data[verifier_len..verifier_len + next_len - 1])?;
+        if e != vf.data[verifier_len + next_len - 1] {
+            return Ok(false);
+        }
+
+        verifier_len += next_len;
+    }
+
+    if verifier_len != vf.data.len() {
+        return Err(PcpError::Decide("long verifier"));
+    }
+
+    Ok(true)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::field::{rand, split, Field126};
+    use crate::pcp::gadgets::{Mul, PolyEval};
     use crate::pcp::types::Boolean;
+    use crate::polynomial::poly_range_check;
+
+    use std::convert::Infallible;
 
     // Simple integration test for the core PCP logic. You'll find more extensive unit tests for
     // each implemented data type in src/types.rs.
     #[test]
     fn test_pcp() {
         type F = Field126;
-        type T = Boolean<F>;
+        type T = TestValue<F>;
+        const NUM_SHARES: usize = 2;
 
-        let query_rand = rand(1).unwrap();
-        let joint_rand = vec![];
-
-        let x: T = Boolean::new(false);
+        let inp = F::from(3);
+        let x: T = TestValue::new(inp);
         let x_par = x.param();
-        let x_shares: Vec<T> = split(x.as_slice(), 2)
+        let x_shares: Vec<T> = split(x.as_slice(), NUM_SHARES)
             .unwrap()
             .into_iter()
-            .map(|data| Boolean::try_from((x_par, data)).unwrap())
+            .enumerate()
+            .map(|(i, data)| {
+                let mut share = T::try_from((x_par, data)).unwrap();
+                share.set_leader(i == 0);
+                share
+            })
             .collect();
 
+        let joint_rand = rand(x.valid_rand_len()).unwrap();
         let pf = prove(&x, &joint_rand).unwrap();
-        let pf_shares: Vec<Proof<F>> = split(pf.as_slice(), 2)
+        let pf_shares: Vec<Proof<F>> = split(pf.as_slice(), NUM_SHARES)
             .unwrap()
             .into_iter()
             .map(Proof::from)
             .collect();
 
-        let vf_shares = vec![
-            query(&x_shares[0], &pf_shares[0], &query_rand, &joint_rand).unwrap(),
-            query(&x_shares[1], &pf_shares[1], &query_rand, &joint_rand).unwrap(),
-        ];
-
+        let query_rand = rand(2).unwrap(); // Length is the same as the length of the gadget
+        let vf_shares: Vec<Verifier<F>> = (0..NUM_SHARES)
+            .map(|i| query(&x_shares[i], &pf_shares[i], &query_rand, &joint_rand).unwrap())
+            .collect();
         let vf = Verifier::try_from(vf_shares.as_slice()).unwrap();
         let res = decide(&x, &vf).unwrap();
-        assert_eq!(res, true);
+        assert_eq!(res, true, "{:?}", vf);
     }
 
     #[test]
@@ -712,5 +831,86 @@ mod tests {
 
         let bad_vf = Verifier::from(vec![]);
         assert!(decide(&x, &bad_vf).is_err());
+    }
+
+    /// A toy type used for testing the functionality in this module. Valid inputs of this type
+    /// consist of a pair of field elements `(x, y)` where `2 <= x < 5` and `x^3 == y`.
+    #[derive(Debug, PartialEq, Eq)]
+    pub struct TestValue<F: FieldElement> {
+        data: Vec<F>, // The encoded input
+    }
+
+    impl<F: FieldElement> TestValue<F> {
+        pub fn new(inp: F) -> Self {
+            Self {
+                data: vec![inp, inp * inp * inp],
+            }
+        }
+    }
+
+    impl<F: FieldElement> Value<F> for TestValue<F> {
+        type Param = ();
+        type TryFromError = Infallible;
+
+        fn valid(&self, g: &mut Vec<Box<dyn Gadget<F>>>, joint_rand: &[F]) -> Result<F, PcpError> {
+            if joint_rand.len() != self.valid_rand_len() {
+                return Err(PcpError::ValidRandLen);
+            }
+
+            if self.data.len() != 2 {
+                return Err(PcpError::CircuitInLen);
+            }
+
+            let r = joint_rand[0];
+            let mut res = F::zero();
+
+            // Check that `data[0]^3 == data[1]`.
+            let mut inp = [self.data[0], self.data[0]];
+            inp[0] = g[0].call(&inp)?;
+            inp[0] = g[0].call(&inp)?;
+            let x3_diff = inp[0] - self.data[1];
+            res += r * x3_diff;
+
+            // Check that `data[0]` is in the correct range.
+            let x_checked = g[1].call(&[self.data[0]])?;
+            res += (r * r) * x_checked;
+
+            Ok(res)
+        }
+
+        fn valid_gadget_calls(&self) -> Vec<usize> {
+            vec![2, 1]
+        }
+
+        fn valid_rand_len(&self) -> usize {
+            1
+        }
+
+        fn valid_gadget_len(&self) -> usize {
+            2
+        }
+
+        fn gadget(&self) -> Vec<Box<dyn Gadget<F>>> {
+            vec![
+                Box::new(Mul::new(2)),
+                Box::new(PolyEval::new(poly_range_check(2, 5), 1)),
+            ]
+        }
+
+        fn as_slice(&self) -> &[F] {
+            &self.data
+        }
+
+        fn param(&self) -> Self::Param {
+            ()
+        }
+    }
+
+    impl<F: FieldElement> TryFrom<((), Vec<F>)> for TestValue<F> {
+        type Error = Infallible;
+
+        fn try_from(val: ((), Vec<F>)) -> Result<Self, Infallible> {
+            Ok(Self { data: val.1 })
+        }
     }
 }


### PR DESCRIPTION
This extends the PCP system to support types whose validity circuits have multiple distinct gadgets.