### PR TITLE
Encoding/decoding affordances for `FieldElement`

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -8,7 +8,7 @@ use crate::{
     field::FieldElement,
     polynomial::{poly_fft, PolyAuxMemory},
     prng::Prng,
-    util::{proof_length, serialize, unpack_proof_mut},
+    util::{proof_length, unpack_proof_mut},
 };
 
 use std::convert::TryFrom;
@@ -99,7 +99,7 @@ impl<F: FieldElement> Client<F> {
         // use prng to share the proof: share2 is the PRNG seed, and proof is mutated
         // in-place
         let share2 = crate::prng::secret_share(&mut proof)?;
-        let share1 = serialize(&proof);
+        let share1 = F::slice_into_byte_vec(&proof);
         // encrypt shares with respective keys
         let encrypted_share1 = encrypt_share(&share1, &self.public_key1)?;
         let encrypted_share2 = encrypt_share(&share2, &self.public_key2)?;

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -114,7 +114,7 @@ fn bitrev(d: usize, x: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::field::{rand, split, Field126, Field32, Field64, Field80};
+    use crate::field::{rand, split, Field126, Field32, Field64, Field80, FieldPriov2};
     use crate::polynomial::{poly_fft, PolyAuxMemory};
 
     fn discrete_fourier_transform_then_inv_test<F: FieldElement>() -> Result<(), FftError> {
@@ -136,6 +136,11 @@ mod tests {
     #[test]
     fn test_field32() {
         discrete_fourier_transform_then_inv_test::<Field32>().expect("unexpected error");
+    }
+
+    #[test]
+    fn test_priov2_field32() {
+        discrete_fourier_transform_then_inv_test::<FieldPriov2>().expect("unexpected error");
     }
 
     #[test]

--- a/src/server.rs
+++ b/src/server.rs
@@ -7,7 +7,7 @@ use crate::{
     field::{merge_vector, FieldElement, FieldError},
     polynomial::{poly_interpret_eval, PolyAuxMemory},
     prng::{extract_share_from_seed, Prng, PrngError},
-    util::{deserialize, proof_length, unpack_proof, SerializeError},
+    util::{proof_length, unpack_proof, SerializeError},
 };
 use serde::{Deserialize, Serialize};
 
@@ -100,7 +100,7 @@ impl<F: FieldElement> Server<F> {
     fn deserialize_share(&self, encrypted_share: &[u8]) -> Result<Vec<F>, ServerError> {
         let share = decrypt_share(encrypted_share, &self.private_key)?;
         Ok(if self.is_first_server {
-            deserialize(&share)?
+            F::byte_slice_into_vec(&share)?
         } else {
             let len = proof_length(self.dimension);
             extract_share_from_seed(len, &share)?

--- a/tests/tweaks.rs
+++ b/tests/tweaks.rs
@@ -6,7 +6,7 @@ use prio::{
     encrypt::{decrypt_share, encrypt_share, PrivateKey, PublicKey},
     field::{Field32, FieldElement},
     server::Server,
-    util::{deserialize, serialize, unpack_proof_mut},
+    util::unpack_proof_mut,
 };
 
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -59,7 +59,7 @@ fn tweaks(tweak: Tweak) {
     let (share1_original, share2) = client_mem.encode_simple(&data).unwrap();
 
     let decrypted_share1 = decrypt_share(&share1_original, &priv_key1_clone).unwrap();
-    let mut share1_field: Vec<Field32> = deserialize(&decrypted_share1).unwrap();
+    let mut share1_field = Field32::byte_slice_into_vec(&decrypted_share1).unwrap();
     let unpacked_share1 = unpack_proof_mut(&mut share1_field, dim).unwrap();
 
     let one = Field32::from(1);
@@ -74,7 +74,11 @@ fn tweaks(tweak: Tweak) {
     };
 
     // reserialize altered share1
-    let share1_modified = encrypt_share(&serialize(&share1_field), &pub_key1_clone).unwrap();
+    let share1_modified = encrypt_share(
+        &Field32::slice_into_byte_vec(&share1_field),
+        &pub_key1_clone,
+    )
+    .unwrap();
 
     let eval_at = server1.choose_eval_at();
 


### PR DESCRIPTION
This series of commits modifies the definition of trait `FieldElement` to add some trait bounds and shuffle some methods and associated functions around to make encoding and decoding of `FieldElement` and `&[FieldElement]` values into/from byte slices a little easier.