### PR TITLE
prng: Define the StreamCipher trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ repository = "https://github.com/abetterinternet/libprio-rs"
 
 [dependencies]
 aes = { version = "0.7.5", features = ["ctr"] }
+blake3 = "1.0.0"
 cipher = "0.3.0"
 aes-gcm = "^0.9"
 base64 = "0.12.3"

--- a/src/client.rs
+++ b/src/client.rs
@@ -7,9 +7,11 @@ use crate::{
     encrypt::{encrypt_share, EncryptError, PublicKey},
     field::FieldElement,
     polynomial::{poly_fft, PolyAuxMemory},
-    prng::Prng,
+    prng::{Prng, STREAM_CIPHER_AES128CTR_KEY_LENGTH},
     util::{proof_length, unpack_proof_mut},
 };
+
+use aes::Aes128Ctr;
 
 use std::convert::TryFrom;
 
@@ -18,7 +20,7 @@ use std::convert::TryFrom;
 /// Client is used to create Prio shares.
 #[derive(Debug)]
 pub struct Client<F: FieldElement> {
-    prng: Prng<F>,
+    prng: Prng<F, Aes128Ctr, STREAM_CIPHER_AES128CTR_KEY_LENGTH>,
     dimension: usize,
     points_f: Vec<F>,
     points_g: Vec<F>,

--- a/src/pcp.rs
+++ b/src/pcp.rs
@@ -126,6 +126,8 @@ use std::any::Any;
 use std::convert::TryFrom;
 use std::fmt::Debug;
 
+use aes::Aes128Ctr;
+
 use crate::fft::{discrete_fourier_transform, discrete_fourier_transform_inv_finish, FftError};
 use crate::field::{FieldElement, FieldError};
 use crate::fp::log2;
@@ -415,7 +417,8 @@ struct ProveShimGadget<F: FieldElement> {
 impl<F: FieldElement> ProveShimGadget<F> {
     fn new(inner: Box<dyn Gadget<F>>, gadget_calls: usize) -> Result<Self, PcpError> {
         let mut f_vals = vec![vec![F::zero(); 1 + gadget_calls]; inner.arity()];
-        let mut prng = Prng::new_with_length(f_vals.len())?;
+        // TODO(cjpatton) Don't hard-code the KeyStream implementation.
+        let mut prng = Prng::<_, Aes128Ctr, 32>::new_with_length(f_vals.len())?;
 
         #[allow(clippy::needless_range_loop)]
         for wire in 0..f_vals.len() {

--- a/src/pcp/gadgets.rs
+++ b/src/pcp/gadgets.rs
@@ -403,7 +403,9 @@ mod tests {
     use super::*;
 
     use crate::field::{rand, Field80 as TestField};
-    use crate::prng::Prng;
+    use crate::prng::{Prng, STREAM_CIPHER_AES128CTR_KEY_LENGTH};
+
+    use aes::Aes128Ctr;
 
     #[test]
     fn test_mul() {
@@ -447,7 +449,7 @@ mod tests {
     // Test that calling g.call_poly() and evaluating the output at a given point is equivalent
     // to evaluating each of the inputs at the same point and applying g.call() on the results.
     fn gadget_test<F: FieldElement, G: Gadget<F>>(g: &mut G, num_calls: usize) {
-        let mut prng = Prng::new().unwrap();
+        let mut prng = Prng::<F, Aes128Ctr, STREAM_CIPHER_AES128CTR_KEY_LENGTH>::new().unwrap();
         let mut inp = vec![F::zero(); g.arity()];
         let mut poly_outp = vec![F::zero(); (g.degree() * (1 + num_calls)).next_power_of_two()];
         let mut poly_inp = vec![vec![F::zero(); 1 + num_calls]; g.arity()];

--- a/src/prng.rs
+++ b/src/prng.rs
@@ -9,7 +9,6 @@ use aes::{
     },
     Aes128, Aes128Ctr,
 };
-use blake3;
 use getrandom::getrandom;
 
 use std::marker::PhantomData;

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,9 +6,10 @@ use crate::{
     encrypt::{decrypt_share, EncryptError, PrivateKey},
     field::{merge_vector, FieldElement, FieldError},
     polynomial::{poly_interpret_eval, PolyAuxMemory},
-    prng::{extract_share_from_seed, Prng, PrngError},
+    prng::{extract_share_from_seed, Prng, PrngError, STREAM_CIPHER_AES128CTR_KEY_LENGTH},
     util::{proof_length, unpack_proof, SerializeError},
 };
+use aes::Aes128Ctr;
 use serde::{Deserialize, Serialize};
 
 /// Possible errors from server operations
@@ -66,7 +67,7 @@ impl<F: FieldElement> ValidationMemory<F> {
 /// Main workhorse of the server.
 #[derive(Debug)]
 pub struct Server<F: FieldElement> {
-    prng: Prng<F>,
+    prng: Prng<F, Aes128Ctr, STREAM_CIPHER_AES128CTR_KEY_LENGTH>,
     dimension: usize,
     is_first_server: bool,
     accumulator: Vec<F>,


### PR DESCRIPTION
This PR does two things:
- Refactors `Prng` to add support for stream ciphers besides AES128-CTR.
- Adds support for BLAKE3.

Notes:
- AES128-CTR is still hard-coded for `rand()` and `split()`. Generalizing these will require making the `prng` module public, but we can do this in a later PR.
- The use of const generics makes instantiating a `Prng` a bit ugly. I think it would be nice to wrap this with a macro per implementation, e.g., `prng_aes128ctr!()` and `prng_blake3!()`. However, I'm not quite sure how to make Rust do what I want it to do.
- BLAKE3 might be slower than AES128-CTR for this application since it lacks hardware support. We should add some benchmarks. The reason I wanted to consider adding it is that we will need a hash function and it's nice to able to use the same primitive for two purposes. But maybe this isn't a good enough reason to add it.
- Another implementation we might consider adding is ChaCha20.