### PR TITLE
prng: Define the StreamCipher trait

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -7,9 +7,11 @@ use crate::{
     encrypt::{encrypt_share, EncryptError, PublicKey},
     field::FieldElement,
     polynomial::{poly_fft, PolyAuxMemory},
-    prng::Prng,
+    prng::{Prng, PrngError},
     util::{proof_length, unpack_proof_mut},
 };
+
+use aes::Aes128Ctr;
 
 use std::convert::TryFrom;
 
@@ -18,7 +20,7 @@ use std::convert::TryFrom;
 /// Client is used to create Prio shares.
 #[derive(Debug)]
 pub struct Client<F: FieldElement> {
-    prng: Prng<F>,
+    prng: Prng<F, Aes128Ctr>,
     dimension: usize,
     points_f: Vec<F>,
     points_g: Vec<F>,
@@ -32,20 +34,20 @@ pub struct Client<F: FieldElement> {
 /// Errors that might be emitted by the client.
 #[derive(Debug, thiserror::Error)]
 pub enum ClientError {
-    /// Thes error is output by `Client<F>::new()` if the length of the proof would exceed the
+    /// This error is output by `Client<F>::new()` if the length of the proof would exceed the
     /// number of roots of unity that can be generated in the field.
     #[error("input size exceeds field capacity")]
     InputSizeExceedsFieldCapacity,
-    /// Thes error is output by `Client<F>::new()` if the length of the proof would exceed the
-    /// ssytem's addressible memory.
+    /// This error is output by `Client<F>::new()` if the length of the proof would exceed the
+    /// system's addressible memory.
     #[error("input size exceeds field capacity")]
     InputSizeExceedsMemoryCapacity,
     /// Encryption/decryption error
     #[error("encryption/decryption error")]
     Encrypt(#[from] EncryptError),
-    /// Failure when calling getrandom().
-    #[error("getrandom: {0}")]
-    GetRandom(#[from] getrandom::Error),
+    /// PRNG error
+    #[error("prng error: {0}")]
+    Prng(#[from] PrngError),
 }
 
 impl<F: FieldElement> Client<F> {

--- a/src/encrypt.rs
+++ b/src/encrypt.rs
@@ -3,6 +3,8 @@
 
 //! Utilities for ECIES encryption / decryption used by the Prio client and server.
 
+use crate::prng::PrngError;
+
 use aes_gcm::aead::generic_array::typenum::U16;
 use aes_gcm::aead::generic_array::GenericArray;
 use aes_gcm::{AeadInPlace, NewAead};
@@ -34,9 +36,9 @@ pub enum EncryptError {
     /// Input ciphertext was too small
     #[error("input ciphertext was too small")]
     DecryptionLength,
-    /// Failure when calling getrandom().
-    #[error("getrandom: {0}")]
-    GetRandom(#[from] getrandom::Error),
+    /// PRNG error
+    #[error("prng error: {0}")]
+    Prng(#[from] PrngError),
 }
 
 /// NIST P-256, public key in X9.62 uncompressed format

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -114,8 +114,9 @@ fn bitrev(d: usize, x: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::field::{rand, split, Field126, Field32, Field64, Field80, FieldPriov2};
+    use crate::field::{split, Field126, Field32, Field64, Field80, FieldPriov2};
     use crate::polynomial::{poly_fft, PolyAuxMemory};
+    use crate::prng::random_vector;
 
     fn discrete_fourier_transform_then_inv_test<F: FieldElement>() -> Result<(), FftError> {
         let test_sizes = [1, 2, 4, 8, 16, 256, 1024, 2048];
@@ -123,7 +124,7 @@ mod tests {
         for size in test_sizes.iter() {
             let mut tmp = vec![F::zero(); *size];
             let mut got = vec![F::zero(); *size];
-            let want = rand(*size).unwrap();
+            let want = random_vector(*size).unwrap();
 
             discrete_fourier_transform(&mut tmp, &want, want.len())?;
             discrete_fourier_transform_inv(&mut got, &tmp, tmp.len())?;
@@ -163,7 +164,7 @@ mod tests {
         let size = 128;
         let mut mem = PolyAuxMemory::new(size / 2);
 
-        let inp = rand(size).unwrap();
+        let inp = random_vector(size).unwrap();
         let mut want = vec![Field32::zero(); size];
         let mut got = vec![Field32::zero(); size];
 
@@ -188,7 +189,7 @@ mod tests {
     fn test_fft_linearity() {
         let len = 16;
         let num_shares = 3;
-        let x: Vec<Field64> = rand(len).unwrap();
+        let x: Vec<Field64> = random_vector(len).unwrap();
         let mut x_shares = split(&x, num_shares).unwrap();
 
         // Just for fun, let's do something different with a subset of the inputs. For the first

--- a/src/pcp.rs
+++ b/src/pcp.rs
@@ -14,7 +14,8 @@
 //! ```
 //! use prio::pcp::types::Boolean;
 //! use prio::pcp::{decide, prove, query, Value};
-//! use prio::field::{rand, FieldElement, Field64};
+//! use prio::field::{FieldElement, Field64};
+//! use prio::prng::random_vector;
 //!
 //! // The prover generates a proof `pf` that its input `x` is a valid encoding
 //! // of a boolean (either `true` or `false`). Both the input and proof are
@@ -25,11 +26,11 @@
 //! // generate and verify a proof of `x`'s validity. In proof systems like
 //! // [BBC+19, Theorem 5.3], the verifier sends the prover a random challenge
 //! // in the first round, which the prover uses to construct the proof.
-//! let joint_rand = rand(input.joint_rand_len()).unwrap();
+//! let joint_rand = random_vector(input.joint_rand_len()).unwrap();
 //!
 //! // The prover and verifier choose local randomness it uses to check the proof.
-//! let prove_rand = rand(input.prove_rand_len()).unwrap();
-//! let query_rand = rand(input.query_rand_len()).unwrap();
+//! let prove_rand = random_vector(input.prove_rand_len()).unwrap();
+//! let query_rand = random_vector(input.query_rand_len()).unwrap();
 //!
 //! // The prover generates the proof.
 //! let proof = prove(&input, &prove_rand, &joint_rand).unwrap();
@@ -47,14 +48,15 @@
 //! ```
 //! use prio::pcp::types::Boolean;
 //! use prio::pcp::{decide, prove, query, Value};
-//! use prio::field::{rand, FieldElement, Field64};
+//! use prio::field::{FieldElement, Field64};
+//! use prio::prng::random_vector;
 //!
 //! use std::convert::TryFrom;
 //!
 //! let input = Boolean::try_from(((), vec![Field64::from(23)].as_slice())).unwrap(); // Invalid input
-//! let joint_rand = rand(input.joint_rand_len()).unwrap();
-//! let prove_rand = rand(input.prove_rand_len()).unwrap();
-//! let query_rand = rand(input.query_rand_len()).unwrap();
+//! let joint_rand = random_vector(input.joint_rand_len()).unwrap();
+//! let prove_rand = random_vector(input.prove_rand_len()).unwrap();
+//! let query_rand = random_vector(input.query_rand_len()).unwrap();
 //! let proof = prove(&input, &prove_rand, &joint_rand).unwrap();
 //! let verifier = query(&input, &proof, &query_rand, &joint_rand).unwrap();
 //! let res = decide(&input, &verifier).unwrap();
@@ -71,7 +73,8 @@
 //! ```
 //! use prio::pcp::types::Boolean;
 //! use prio::pcp::{decide, prove, query, Value, Proof, Verifier};
-//! use prio::field::{rand, split, FieldElement, Field64};
+//! use prio::field::{split, FieldElement, Field64};
+//! use prio::prng::random_vector;
 //!
 //! use std::convert::TryFrom;
 //!
@@ -84,9 +87,9 @@
 //!     .map(|data| Boolean::try_from((input.param(), data.as_slice())).unwrap())
 //!     .collect();
 //!
-//! let joint_rand = rand(input.joint_rand_len()).unwrap();
-//! let prove_rand = rand(input.prove_rand_len()).unwrap();
-//! let query_rand = rand(input.query_rand_len()).unwrap();
+//! let joint_rand = random_vector(input.joint_rand_len()).unwrap();
+//! let prove_rand = random_vector(input.prove_rand_len()).unwrap();
+//! let query_rand = random_vector(input.query_rand_len()).unwrap();
 //!
 //! // The prover generates a proof of its input's validity and splits the proof
 //! // into two shares. It sends each share to one of two aggregators.
@@ -224,10 +227,11 @@ pub trait Value<F: FieldElement>:
     /// ```
     /// use prio::pcp::types::Boolean;
     /// use prio::pcp::Value;
-    /// use prio::field::{rand, FieldElement, Field64};
+    /// use prio::field::{FieldElement, Field64};
+    /// use prio::prng::random_vector;
     ///
     /// let x: Boolean<Field64> = Boolean::new(false);
-    /// let joint_rand = rand(x.joint_rand_len()).unwrap();
+    /// let joint_rand = random_vector(x.joint_rand_len()).unwrap();
     /// let v = x.valid(&mut x.gadget(), &joint_rand).unwrap();
     /// assert_eq!(v, Field64::zero());
     /// ```
@@ -273,7 +277,8 @@ pub trait Value<F: FieldElement>:
     /// ```
     /// use prio::pcp::types::MeanVarUnsignedVector;
     /// use prio::pcp::{decide, prove, query, Value, Proof, Verifier};
-    /// use prio::field::{split, rand, FieldElement, Field64};
+    /// use prio::field::{split, FieldElement, Field64};
+    /// use prio::prng::random_vector;
     ///
     /// use std::convert::TryFrom;
     ///
@@ -293,9 +298,9 @@ pub trait Value<F: FieldElement>:
     ///     })
     ///     .collect();
     ///
-    /// let joint_rand = rand(input.joint_rand_len()).unwrap();
-    /// let prove_rand = rand(input.prove_rand_len()).unwrap();
-    /// let query_rand = rand(input.query_rand_len()).unwrap();
+    /// let joint_rand = random_vector(input.joint_rand_len()).unwrap();
+    /// let prove_rand = random_vector(input.prove_rand_len()).unwrap();
+    /// let query_rand = random_vector(input.query_rand_len()).unwrap();
     ///
     /// let proof = prove(&input, &prove_rand, &joint_rand).unwrap();
     /// let proof_shares: Vec<Proof<Field64>> = split(proof.as_slice(), 2)
@@ -805,11 +810,12 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::field::{rand, split, Field126};
+    use crate::field::{split, Field126};
     use crate::pcp::gadgets::{Mul, PolyEval};
     use crate::pcp::types::Boolean;
     use crate::pcp::types::TypeError;
     use crate::polynomial::poly_range_check;
+    use crate::prng::random_vector;
 
     // Simple integration test for the core PCP logic. You'll find more extensive unit tests for
     // each implemented data type in src/types.rs.
@@ -833,9 +839,9 @@ mod tests {
             })
             .collect();
 
-        let joint_rand = rand(x.joint_rand_len()).unwrap();
-        let prove_rand = rand(x.prove_rand_len()).unwrap();
-        let query_rand = rand(x.query_rand_len()).unwrap();
+        let joint_rand = random_vector(x.joint_rand_len()).unwrap();
+        let prove_rand = random_vector(x.prove_rand_len()).unwrap();
+        let query_rand = random_vector(x.query_rand_len()).unwrap();
 
         let pf = prove(&x, &prove_rand, &joint_rand).unwrap();
         let pf_shares: Vec<Proof<F>> = split(pf.as_slice(), NUM_SHARES)
@@ -854,9 +860,9 @@ mod tests {
     #[test]
     fn test_decide() {
         let x: Boolean<Field126> = Boolean::new(true);
-        let joint_rand = rand(x.joint_rand_len()).unwrap();
-        let prove_rand = rand(x.prove_rand_len()).unwrap();
-        let query_rand = rand(x.query_rand_len()).unwrap();
+        let joint_rand = random_vector(x.joint_rand_len()).unwrap();
+        let prove_rand = random_vector(x.prove_rand_len()).unwrap();
+        let query_rand = random_vector(x.query_rand_len()).unwrap();
 
         let ok_vf = query(
             &x,

--- a/src/pcp/gadgets.rs
+++ b/src/pcp/gadgets.rs
@@ -402,7 +402,9 @@ where
 mod tests {
     use super::*;
 
-    use crate::field::{rand, Field80 as TestField};
+    use aes::Aes128Ctr;
+
+    use crate::field::Field80 as TestField;
     use crate::prng::Prng;
 
     #[test]
@@ -422,7 +424,10 @@ mod tests {
 
     #[test]
     fn test_poly_eval() {
-        let poly = rand(10).unwrap();
+        let poly: Vec<TestField> = Prng::<TestField, Aes128Ctr>::new()
+            .unwrap()
+            .take(10)
+            .collect();
 
         let num_calls = FFT_THRESHOLD / 2;
         let mut g: PolyEval<TestField> = PolyEval::new(poly.clone(), num_calls);
@@ -447,7 +452,7 @@ mod tests {
     // Test that calling g.call_poly() and evaluating the output at a given point is equivalent
     // to evaluating each of the inputs at the same point and applying g.call() on the results.
     fn gadget_test<F: FieldElement, G: Gadget<F>>(g: &mut G, num_calls: usize) {
-        let mut prng = Prng::new().unwrap();
+        let mut prng: Prng<F, Aes128Ctr> = Prng::new().unwrap();
         let mut inp = vec![F::zero(); g.arity()];
         let mut poly_outp = vec![F::zero(); (g.degree() * (1 + num_calls)).next_power_of_two()];
         let mut poly_inp = vec![vec![F::zero(); 1 + num_calls]; g.arity()];

--- a/src/pcp/types.rs
+++ b/src/pcp/types.rs
@@ -359,8 +359,10 @@ impl<F: FieldElement> TryFrom<(usize, &[F])> for MeanVarUnsignedVector<F> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::field::{rand, split, Field64 as TestField};
+    use crate::field::{split, Field64 as TestField};
     use crate::pcp::{decide, prove, query, Proof, Value, Verifier};
+    use crate::prng::random_vector;
+
     use assert_matches::assert_matches;
 
     // Number of shares to split input and proofs into in `pcp_test`.
@@ -599,9 +601,9 @@ mod tests {
         V: Value<F>,
     {
         let mut gadgets = input.gadget();
-        let joint_rand = rand(input.joint_rand_len()).unwrap();
-        let prove_rand = rand(input.prove_rand_len()).unwrap();
-        let query_rand = rand(input.query_rand_len()).unwrap();
+        let joint_rand = random_vector(input.joint_rand_len()).unwrap();
+        let prove_rand = random_vector(input.prove_rand_len()).unwrap();
+        let query_rand = random_vector(input.query_rand_len()).unwrap();
 
         assert_eq!(input.query_rand_len(), gadgets.len());
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -9,6 +9,7 @@ use crate::{
     prng::{extract_share_from_seed, Prng, PrngError},
     util::{proof_length, unpack_proof, SerializeError},
 };
+use aes::Aes128Ctr;
 use serde::{Deserialize, Serialize};
 
 /// Possible errors from server operations
@@ -58,7 +59,7 @@ impl<F: FieldElement> ValidationMemory<F> {
 /// Main workhorse of the server.
 #[derive(Debug)]
 pub struct Server<F: FieldElement> {
-    prng: Prng<F>,
+    prng: Prng<F, Aes128Ctr>,
     dimension: usize,
     is_first_server: bool,
     accumulator: Vec<F>,


### PR DESCRIPTION
Struct Prng uses AES128-CTR as a stream cipher. This commit defines a
trait StreamCipher for stream ciphers and generalizes Prng to use any
implementation of this trait. It also adds an implementation of
StreamCipher for BLAKE3 (https://docs.rs/blake3/1.0.0/blake3). While at
it, this commit reduces the internal API surface for Prng.