### PR TITLE
Adopt serde for various types

### DIFF
--- a/src/pcp.rs
+++ b/src/pcp.rs
@@ -127,15 +127,15 @@
 //! - \[BBC+19\] Boneh et al. "[Zero-Knowledge Proofs on Secret-Shared Data via Fully Linear
 //! PCPs.](https://eprint.iacr.org/2019/188)" CRYPTO 2019.
 
-use std::any::Any;
-use std::convert::TryFrom;
-use std::fmt::Debug;
-
 use crate::fft::{discrete_fourier_transform, discrete_fourier_transform_inv_finish, FftError};
 use crate::field::{FieldElement, FieldError};
 use crate::fp::log2;
 use crate::pcp::types::TypeError;
 use crate::polynomial::poly_eval;
+use serde::{Deserialize, Serialize};
+use std::any::Any;
+use std::convert::TryFrom;
+use std::fmt::Debug;
 
 pub mod gadgets;
 pub mod types;
@@ -717,7 +717,7 @@ impl<F: FieldElement> Gadget<F> for QueryShimGadget<F> {
 }
 
 /// The output of `query`, the verifier message generated for a proof.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Verifier<F: FieldElement> {
     pub(crate) data: Vec<F>,
 }

--- a/src/pcp/types.rs
+++ b/src/pcp/types.rs
@@ -19,7 +19,7 @@ pub enum TypeError {
 }
 
 /// Values of this type encode a simple boolean (either `true` or `false`).
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Boolean<F: FieldElement> {
     data: Vec<F>,  // The encoded input
     range: Vec<F>, // A range check polynomial for [0, 2)
@@ -113,7 +113,7 @@ impl<F: FieldElement> TryFrom<((), &[F])> for Boolean<F> {
 /// ```
 /// The proof technique is based on the SIMD circuit construction of
 /// \[[BBG+19](https://eprint.iacr.org/2019/188), Theorem 5.3\].
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PolyCheckedVector<F: FieldElement> {
     data: Vec<F>,
     poly: Vec<F>,
@@ -196,7 +196,7 @@ impl<F: FieldElement> TryFrom<(Vec<F>, &[F])> for PolyCheckedVector<F> {
 /// `xx`, which is the integer raised to the power of two. The validity circuit checks that the
 /// integer represented by `x_vec` is the square root of `xx`. It is based on the SIMD circuit of
 /// \[BBG+19, Theorem 5.3\].
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MeanVarUnsignedVector<F: FieldElement> {
     data: Vec<F>,
     /// The maximum length of each integer.

--- a/src/ppm.rs
+++ b/src/ppm.rs
@@ -33,16 +33,14 @@
 //! NOTE: This protocol implemented here is a prototype and has not undergone security analysis.
 //! Use at your own risk.
 
-use std::convert::TryFrom;
-
-use getrandom::getrandom;
-
-use aes::Aes128Ctr;
-
 use crate::field::FieldElement;
 use crate::pcp::types::TypeError;
 use crate::pcp::{decide, prove, query, PcpError, Proof, Value, Verifier};
 use crate::prng::{Prng, PrngError, StreamCipher};
+use aes::Aes128Ctr;
+use getrandom::getrandom;
+use serde::{Deserialize, Serialize};
+use std::convert::TryFrom;
 
 /// Errors emitted by this module.
 #[derive(Debug, thiserror::Error)]
@@ -73,7 +71,7 @@ pub enum PpmError {
 }
 
 /// A share of an input or proof for Prio.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum Share<F: FieldElement> {
     /// An uncompressed share, typically sent to the leader.
     Leader(Vec<F>),
@@ -103,7 +101,7 @@ impl<F: FieldElement> TryFrom<Share<F>> for Vec<F> {
 
 /// The message sent by the client to each aggregator. This includes the client's input share and
 /// the initial message of the input-validation protocol.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct UploadMessage<F: FieldElement> {
     /// The input share.
     pub input_share: Share<F>,
@@ -306,7 +304,7 @@ where
 
 /// The message sent by an aggregator to every other aggregator. This is the final message of the
 /// input-validation protocol.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct VerifierMessage<F: FieldElement> {
     /// The aggregator's share of the verifier message.
     pub verifier_share: Verifier<F>,


### PR DESCRIPTION
Adds derivations of `serde::Serialize` and `serde::Deserialize` for a
number of types. We provide custom implementations for trait
`FieldElement` for the reasons noted in the source comments. We may yet
want to provide more specialized serialization for `[F: FieldElement]`
or `Vec<F: FieldElement>`.

These custom impls replace the existing derived impls. This should not
present any backward compatibility problems because the existing client
of crate `prio` doesn't use `serde` to encode values.