### PR TITLE
ppm: Have verify_finish() consume the output of verify_start()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod field;
 mod fp;
 pub mod pcp;
 mod polynomial;
-pub mod ppm;
 pub mod prng;
 pub mod server;
 pub mod util;
+pub mod vdaf;

--- a/src/pcp.rs
+++ b/src/pcp.rs
@@ -719,7 +719,7 @@ impl<F: FieldElement> Gadget<F> for QueryShimGadget<F> {
 /// The output of `query`, the verifier message generated for a proof.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct Verifier<F: FieldElement> {
-    pub(crate) data: Vec<F>,
+    data: Vec<F>,
 }
 
 impl<F: FieldElement> Verifier<F> {


### PR DESCRIPTION
This aligns better with the spec and also simplifies the code a bit.