### PR TITLE
Replace trait StreamCipher with concrete struct

### DIFF
--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -5,11 +5,10 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use prio::benchmarked::*;
 use prio::client::Client;
 use prio::encrypt::PublicKey;
-use prio::field::{Field126 as F, FieldElement};
+use prio::field::{random_vector, Field126 as F, FieldElement};
 use prio::pcp::gadgets::Mul;
 use prio::pcp::types::{MeanVarUnsignedVector, PolyCheckedVector};
 use prio::pcp::{prove, query, Value};
-use prio::prng::random_vector;
 use prio::server::{generate_verification_message, ValidationMemory};
 
 /// This benchmark compares the performance of recursive and iterative FFT.

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,9 +9,8 @@ use crate::{
     polynomial::{poly_fft, PolyAuxMemory},
     prng::{Prng, PrngError},
     util::{proof_length, unpack_proof_mut},
+    vdaf::suite::Suite,
 };
-
-use aes::Aes128Ctr;
 
 use std::convert::TryFrom;
 
@@ -20,7 +19,7 @@ use std::convert::TryFrom;
 /// Client is used to create Prio shares.
 #[derive(Debug)]
 pub struct Client<F: FieldElement> {
-    prng: Prng<F, Aes128Ctr>,
+    prng: Prng<F>,
     dimension: usize,
     points_f: Vec<F>,
     points_g: Vec<F>,
@@ -68,7 +67,7 @@ impl<F: FieldElement> Client<F> {
         }
 
         Ok(Client {
-            prng: Prng::new()?,
+            prng: Prng::generate(Suite::Aes128CtrHmacSha256)?,
             dimension,
             points_f: vec![F::zero(); n],
             points_g: vec![F::zero(); n],

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -114,9 +114,8 @@ fn bitrev(d: usize, x: usize) -> usize {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::field::{split, Field126, Field32, Field64, Field80, FieldPriov2};
+    use crate::field::{random_vector, split, Field126, Field32, Field64, Field80, FieldPriov2};
     use crate::polynomial::{poly_fft, PolyAuxMemory};
-    use crate::prng::random_vector;
 
     fn discrete_fourier_transform_then_inv_test<F: FieldElement>() -> Result<(), FftError> {
         let test_sizes = [1, 2, 4, 8, 16, 256, 1024, 2048];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub mod field;
 mod fp;
 pub mod pcp;
 mod polynomial;
-pub mod prng;
+mod prng;
 pub mod server;
 pub mod util;
 pub mod vdaf;

--- a/src/pcp.rs
+++ b/src/pcp.rs
@@ -14,8 +14,7 @@
 //! ```
 //! use prio::pcp::types::Boolean;
 //! use prio::pcp::{decide, prove, query, Value};
-//! use prio::field::{FieldElement, Field64};
-//! use prio::prng::random_vector;
+//! use prio::field::{random_vector, FieldElement, Field64};
 //!
 //! // The prover generates a proof `pf` that its input `x` is a valid encoding
 //! // of a boolean (either `true` or `false`). Both the input and proof are
@@ -48,8 +47,7 @@
 //! ```
 //! use prio::pcp::types::Boolean;
 //! use prio::pcp::{decide, prove, query, Value};
-//! use prio::field::{FieldElement, Field64};
-//! use prio::prng::random_vector;
+//! use prio::field::{random_vector, FieldElement, Field64};
 //!
 //! use std::convert::TryFrom;
 //!
@@ -73,8 +71,7 @@
 //! ```
 //! use prio::pcp::types::Boolean;
 //! use prio::pcp::{decide, prove, query, Value, Proof, Verifier};
-//! use prio::field::{split, FieldElement, Field64};
-//! use prio::prng::random_vector;
+//! use prio::field::{split, random_vector, FieldElement, Field64};
 //!
 //! use std::convert::TryFrom;
 //!
@@ -141,6 +138,7 @@ pub mod gadgets;
 pub mod types;
 
 /// Errors propagated by methods in this module.
+// TODO(cjpatton) Consolidate the set of errors here. Lots of variants isn't super helpful.
 #[derive(Debug, thiserror::Error)]
 pub enum PcpError {
     /// The caller of an arithmetic circuit provided the wrong number of inputs. This error may
@@ -227,8 +225,7 @@ pub trait Value<F: FieldElement>:
     /// ```
     /// use prio::pcp::types::Boolean;
     /// use prio::pcp::Value;
-    /// use prio::field::{FieldElement, Field64};
-    /// use prio::prng::random_vector;
+    /// use prio::field::{random_vector, FieldElement, Field64};
     ///
     /// let x: Boolean<Field64> = Boolean::new(false);
     /// let joint_rand = random_vector(x.joint_rand_len()).unwrap();
@@ -277,8 +274,7 @@ pub trait Value<F: FieldElement>:
     /// ```
     /// use prio::pcp::types::MeanVarUnsignedVector;
     /// use prio::pcp::{decide, prove, query, Value, Proof, Verifier};
-    /// use prio::field::{split, FieldElement, Field64};
-    /// use prio::prng::random_vector;
+    /// use prio::field::{random_vector, split, FieldElement, Field64};
     ///
     /// use std::convert::TryFrom;
     ///
@@ -810,12 +806,11 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::field::{split, Field126};
+    use crate::field::{random_vector, split, Field126};
     use crate::pcp::gadgets::{Mul, PolyEval};
     use crate::pcp::types::Boolean;
     use crate::pcp::types::TypeError;
     use crate::polynomial::poly_range_check;
-    use crate::prng::random_vector;
 
     // Simple integration test for the core PCP logic. You'll find more extensive unit tests for
     // each implemented data type in src/types.rs.

--- a/src/pcp/gadgets.rs
+++ b/src/pcp/gadgets.rs
@@ -402,10 +402,9 @@ where
 mod tests {
     use super::*;
 
-    use aes::Aes128Ctr;
-
     use crate::field::Field80 as TestField;
     use crate::prng::Prng;
+    use crate::vdaf::suite::Suite;
 
     #[test]
     fn test_mul() {
@@ -424,10 +423,7 @@ mod tests {
 
     #[test]
     fn test_poly_eval() {
-        let poly: Vec<TestField> = Prng::<TestField, Aes128Ctr>::new()
-            .unwrap()
-            .take(10)
-            .collect();
+        let poly: Vec<TestField> = Prng::generate(Suite::Blake3).unwrap().take(10).collect();
 
         let num_calls = FFT_THRESHOLD / 2;
         let mut g: PolyEval<TestField> = PolyEval::new(poly.clone(), num_calls);
@@ -452,7 +448,7 @@ mod tests {
     // Test that calling g.call_poly() and evaluating the output at a given point is equivalent
     // to evaluating each of the inputs at the same point and applying g.call() on the results.
     fn gadget_test<F: FieldElement, G: Gadget<F>>(g: &mut G, num_calls: usize) {
-        let mut prng: Prng<F, Aes128Ctr> = Prng::new().unwrap();
+        let mut prng: Prng<F> = Prng::generate(Suite::Blake3).unwrap();
         let mut inp = vec![F::zero(); g.arity()];
         let mut poly_outp = vec![F::zero(); (g.degree() * (1 + num_calls)).next_power_of_two()];
         let mut poly_inp = vec![vec![F::zero(); 1 + num_calls]; g.arity()];

--- a/src/pcp/types.rs
+++ b/src/pcp/types.rs
@@ -359,9 +359,8 @@ impl<F: FieldElement> TryFrom<(usize, &[F])> for MeanVarUnsignedVector<F> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::field::{split, Field64 as TestField};
+    use crate::field::{random_vector, split, Field64 as TestField};
     use crate::pcp::{decide, prove, query, Proof, Value, Verifier};
-    use crate::prng::random_vector;
 
     use assert_matches::assert_matches;
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -8,8 +8,8 @@ use crate::{
     polynomial::{poly_interpret_eval, PolyAuxMemory},
     prng::{extract_share_from_seed, Prng, PrngError},
     util::{proof_length, unpack_proof, SerializeError},
+    vdaf::suite::Suite,
 };
-use aes::Aes128Ctr;
 use serde::{Deserialize, Serialize};
 
 /// Possible errors from server operations
@@ -59,7 +59,7 @@ impl<F: FieldElement> ValidationMemory<F> {
 /// Main workhorse of the server.
 #[derive(Debug)]
 pub struct Server<F: FieldElement> {
-    prng: Prng<F, Aes128Ctr>,
+    prng: Prng<F>,
     dimension: usize,
     is_first_server: bool,
     accumulator: Vec<F>,
@@ -80,7 +80,7 @@ impl<F: FieldElement> Server<F> {
         private_key: PrivateKey,
     ) -> Result<Server<F>, ServerError> {
         Ok(Server {
-            prng: Prng::new()?,
+            prng: Prng::generate(Suite::Aes128CtrHmacSha256)?,
             dimension,
             is_first_server,
             accumulator: vec![F::zero(); dimension],

--- a/src/vdaf/suite.rs
+++ b/src/vdaf/suite.rs
@@ -1,0 +1,218 @@
+// SPDX-License-Identifier: MPL-2.0
+
+//! This module implements the cryptographic dependencies for our VDAF implementation. This
+//! includes a stream cipher (here we call it a [`KeyStream`]) and a pseudorandom function whose
+//! output size is the same as the key size (we call this a [`KeyDeriver`]).
+//!
+//! TODO(cjpatton) Add unit test with test vectors.
+
+use aes::cipher::generic_array::GenericArray;
+use aes::cipher::{FromBlockCipher, NewBlockCipher, StreamCipher as AesStreamCipher};
+use aes::{Aes128, Aes128Ctr};
+use getrandom::getrandom;
+use ring::hmac;
+use serde::{Deserialize, Serialize};
+
+const BLAKE3_DERIVE_PREFIX: &[u8] = b"blake3 key derive";
+const BLAKE3_STREAM_PREFIX: &[u8] = b"blake3 key stream";
+
+/// Errors propagated by methods in this module.
+#[derive(Debug, PartialEq, thiserror::Error)]
+pub enum SuiteError {
+    /// Failure when calling getrandom().
+    #[error("getrandom: {0}")]
+    GetRandom(#[from] getrandom::Error),
+}
+
+/// A suite uniquely determines a [`KeyStream`] and [`KeyDeriver`].
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum Suite {
+    /// The [`KeyStream`] is implemented from AES128 in CTR mode and the [`KeyDeriver`] is
+    /// implemented from HMAC-SHA256.
+    Aes128CtrHmacSha256,
+
+    /// Both primitives are implemented using the BLAKE3 keyed hash function. The [`KeyStream']
+    /// uses the XOF mode and the [`KeyDeriver`] uses the standard, fixed-sized output mode.
+    Blake3,
+}
+
+/// A Key used to instantiate a [`KeyStream`] or [`KeyDeriver`].
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum Key {
+    #[allow(missing_docs)]
+    Aes128CtrHmacSha256([u8; 32]),
+
+    #[allow(missing_docs)]
+    Blake3([u8; 32]),
+}
+
+impl PartialEq for Key {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Aes128CtrHmacSha256(left), Self::Aes128CtrHmacSha256(right))
+            | (Self::Blake3(left), Self::Blake3(right)) => {
+                // Do constant-time compare.
+                let mut r = 0;
+                for (x, y) in (&left[..]).iter().zip(&right[..]) {
+                    r |= x ^ y;
+                }
+                r == 0
+            }
+            _ => false,
+        }
+    }
+}
+
+impl Key {
+    /// Generates a uniform random key of the type determined by `suite`.
+    pub fn generate(suite: Suite) -> Result<Self, SuiteError> {
+        match suite {
+            Suite::Aes128CtrHmacSha256 => {
+                let mut key = [0; 32];
+                getrandom(&mut key)?;
+                Ok(Key::Aes128CtrHmacSha256(key))
+            }
+            Suite::Blake3 => {
+                let mut key = [0; 32];
+                getrandom(&mut key)?;
+                Ok(Key::Blake3(key))
+            }
+        }
+    }
+
+    /// Returns an uninitialized (i.e., zero-valued) key. The caller is expected to initialize the
+    /// key with a (pseudo)random input.
+    pub(crate) fn uninitialized(suite: Suite) -> Self {
+        match suite {
+            Suite::Aes128CtrHmacSha256 => Key::Aes128CtrHmacSha256([0; 32]),
+            Suite::Blake3 => Key::Blake3([0; 32]),
+        }
+    }
+
+    /// Returns a reference to the underlying data.
+    pub(crate) fn as_slice(&self) -> &[u8] {
+        match self {
+            Self::Aes128CtrHmacSha256(key) => &key[..],
+            Self::Blake3(key) => &key[..],
+        }
+    }
+
+    /// Returns a mutable reference to the underlying data.
+    pub(crate) fn as_mut_slice(&mut self) -> &mut [u8] {
+        match self {
+            Self::Aes128CtrHmacSha256(key) => &mut key[..],
+            Self::Blake3(key) => &mut key[..],
+        }
+    }
+
+    /// Returns the suite for this key.
+    pub(crate) fn suite(&self) -> Suite {
+        match self {
+            Key::Aes128CtrHmacSha256(_) => Suite::Aes128CtrHmacSha256,
+            Key::Blake3(_) => Suite::Blake3,
+        }
+    }
+}
+
+/// A KeyStream expands a key into a stream of pseudorandom bytes.
+#[derive(Debug)]
+pub enum KeyStream {
+    #[allow(missing_docs)]
+    Aes128CtrHmacSha256(Aes128Ctr),
+
+    #[allow(missing_docs)]
+    Blake3(blake3::OutputReader),
+}
+
+impl KeyStream {
+    /// Constructs a key expander from a key.
+    pub fn from_key(key: &Key) -> Self {
+        match key {
+            Key::Aes128CtrHmacSha256(key) => {
+                // The first 16 bytes of the key and the last 16 bytes of the key are used, respectively,
+                // for the key and initialization vector for AES128 in CTR mode.
+                let aes_ctr_key = GenericArray::from_slice(&key[..16]);
+                let aes_ctr_iv = GenericArray::from_slice(&key[16..]);
+                Self::Aes128CtrHmacSha256(Aes128Ctr::from_block_cipher(
+                    Aes128::new(aes_ctr_key),
+                    aes_ctr_iv,
+                ))
+            }
+            Key::Blake3(key) => {
+                const_assert_eq!(BLAKE3_STREAM_PREFIX.len(), BLAKE3_DERIVE_PREFIX.len());
+                let mut hasher = blake3::Hasher::new_keyed(key);
+                hasher.update(BLAKE3_STREAM_PREFIX);
+                Self::Blake3(hasher.finalize_xof())
+            }
+        }
+    }
+
+    /// Fills the buffer `out` with the next `out.len()` bytes of the key stream.
+    pub fn fill(&mut self, out: &mut [u8]) {
+        match self {
+            Self::Aes128CtrHmacSha256(aes128_ctr) => aes128_ctr.apply_keystream(out),
+            Self::Blake3(output_reader) => output_reader.fill(out),
+        }
+    }
+}
+
+/// A KeyDeriver is a pseudorandom function whose output is a [`Key`] object.
+#[derive(Debug)]
+pub enum KeyDeriver {
+    #[allow(missing_docs)]
+    Blake3(blake3::Hasher),
+
+    #[allow(missing_docs)]
+    Aes128CtrHmacSha256(hmac::Context),
+}
+
+impl KeyDeriver {
+    /// Initializes the function with the given key.
+    pub fn from_key(key: &Key) -> Self {
+        match key {
+            Key::Aes128CtrHmacSha256(key) => {
+                let key = hmac::Key::new(hmac::HMAC_SHA256, &key[..]);
+                let context = hmac::Context::with_key(&key);
+                Self::Aes128CtrHmacSha256(context)
+            }
+            Key::Blake3(key) => {
+                let mut hasher = blake3::Hasher::new_keyed(key);
+                hasher.update(BLAKE3_DERIVE_PREFIX);
+                Self::Blake3(hasher)
+            }
+        }
+    }
+
+    /// Appends `input` to the function's input.
+    pub fn update(&mut self, input: &[u8]) {
+        match self {
+            Self::Aes128CtrHmacSha256(context) => {
+                context.update(input);
+            }
+            Self::Blake3(hasher) => {
+                hasher.update(input);
+            }
+        }
+    }
+
+    /// Returns the output of the function.
+    pub fn finish(&self) -> Key {
+        match self {
+            Self::Aes128CtrHmacSha256(context) => {
+                let context = context.clone();
+                let tag = context.sign();
+                let tag = tag.as_ref();
+                if tag.len() != 32 {
+                    // This should never happen.
+                    panic!("tag length is {}; expected 32", tag.len());
+                }
+
+                let mut key = [0; 32];
+                key.copy_from_slice(tag);
+                Key::Aes128CtrHmacSha256(key)
+            }
+            Self::Blake3(hasher) => Key::Blake3(*hasher.finalize().as_bytes()),
+        }
+    }
+}


### PR DESCRIPTION
Based on #80 (review that first).

Creates a new module, `vdaf::suite`, which implements the low-level cryptographic functionalities shared by `vdaf` and `prng`.

NOTE I've temporarily commented out the serde stuff in `vdaf`. The reason is that I'm not quite sure how this is going to work for for different variants of `vdaf::suite::Suite`. I'd appreciate your feedback here.