### PR TITLE
Add Serde trait bounds to `field::FieldElement`

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -11,7 +11,10 @@ use crate::{
     prng::{Prng, PrngError},
     vdaf::suite::Suite,
 };
-use serde::{de::Visitor, Deserialize, Deserializer, Serialize, Serializer};
+use serde::{
+    de::{DeserializeOwned, Visitor},
+    Deserialize, Deserializer, Serialize, Serializer,
+};
 use std::{
     cmp::min,
     convert::TryFrom,
@@ -73,6 +76,8 @@ pub trait FieldElement:
     // isn't possible yet[1]. However we can provide the impl on FieldElement implementations.
     // [1]: https://github.com/rust-lang/rust/issues/60551
     + Into<Vec<u8>>
+    + Serialize
+    + DeserializeOwned
     + 'static // NOTE This bound is needed for downcasting a `dyn Gadget<F>>` to a concrete type.
 {
     /// Size in bytes of the encoding of a value.

--- a/src/pcp.rs
+++ b/src/pcp.rs
@@ -723,7 +723,7 @@ impl<F: FieldElement> Gadget<F> for QueryShimGadget<F> {
 
 /// The output of `query`, the verifier message generated for a proof.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct Verifier<F: FieldElement> {
+pub struct Verifier<F> {
     data: Vec<F>,
 }
 

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -9,7 +9,7 @@ use std::convert::TryFrom;
 
 /// Temporary memory used for FFT
 #[derive(Debug)]
-pub struct PolyFFTTempMemory<F: FieldElement> {
+pub struct PolyFFTTempMemory<F> {
     fft_tmp: Vec<F>,
     fft_y_sub: Vec<F>,
     fft_roots_sub: Vec<F>,
@@ -27,7 +27,7 @@ impl<F: FieldElement> PolyFFTTempMemory<F> {
 
 /// Auxiliary memory for polynomial interpolation and evaluation
 #[derive(Debug)]
-pub struct PolyAuxMemory<F: FieldElement> {
+pub struct PolyAuxMemory<F> {
     pub roots_2n: Vec<F>,
     pub roots_2n_inverted: Vec<F>,
     pub roots_n: Vec<F>,

--- a/src/prng.rs
+++ b/src/prng.rs
@@ -57,7 +57,7 @@ pub enum PrngError {
 /// This type implements an iterator that generates a pseudorandom sequence of field elements. The
 /// sequence is derived from the key stream of AES-128 in CTR mode with a random IV.
 #[derive(Debug)]
-pub(crate) struct Prng<F: FieldElement> {
+pub(crate) struct Prng<F> {
     phantom: PhantomData<F>,
     key_stream: KeyStream,
     buffer: Vec<u8>,

--- a/src/server.rs
+++ b/src/server.rs
@@ -35,7 +35,7 @@ pub enum ServerError {
 /// Auxiliary memory for constructing a
 /// [`VerificationMessage`](struct.VerificationMessage.html)
 #[derive(Debug)]
-pub struct ValidationMemory<F: FieldElement> {
+pub struct ValidationMemory<F> {
     points_f: Vec<F>,
     points_g: Vec<F>,
     points_h: Vec<F>,
@@ -58,7 +58,7 @@ impl<F: FieldElement> ValidationMemory<F> {
 
 /// Main workhorse of the server.
 #[derive(Debug)]
-pub struct Server<F: FieldElement> {
+pub struct Server<F> {
     prng: Prng<F>,
     dimension: usize,
     is_first_server: bool,
@@ -179,7 +179,7 @@ impl<F: FieldElement> Server<F> {
 
 /// Verification message for proof validation
 #[derive(Debug, Serialize, Deserialize)]
-pub struct VerificationMessage<F: FieldElement> {
+pub struct VerificationMessage<F> {
     /// f evaluated at random point
     pub f_r: F,
     /// g evaluated at random point

--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -47,7 +47,7 @@ pub enum VdafError {
 
 /// A share of an input or proof for Prio.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub enum Share<F: FieldElement> {
+pub enum Share<F> {
     /// An uncompressed share, typically sent to the leader.
     Leader(Vec<F>),
 
@@ -77,7 +77,7 @@ impl<F: FieldElement> TryFrom<Share<F>> for Vec<F> {
 /// The message sent by the client to each aggregator. This includes the client's input share and
 /// the initial message of the input-validation protocol.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct InputShareMessage<F: FieldElement> {
+pub struct InputShareMessage<F> {
     /// The input share.
     pub input_share: Share<F>,
 
@@ -243,7 +243,7 @@ pub fn dist_input<V: Value>(
 /// The message sent by an aggregator to every other aggregator. This is the final message of the
 /// input-validation protocol.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct VerifierMessage<F: FieldElement> {
+pub struct VerifierMessage<F> {
     /// The aggregator's share of the verifier message.
     pub verifier_share: Verifier<F>,
 


### PR DESCRIPTION
We already provide `serde::{Serialize, Deserialize}` implementations for
every implementation of `prio::field::FieldElement`, but we didn't
`express that trait bound on `FieldElement` itself. This makes it tricky
to serialize or deserialize `FieldElement` values in generic functions.

To make this possible, we also change the declaration of various
structs so that the `F: FieldElement` trait bound is on the `impl` and
not the `struct`. See
https://github.com/rust-lang/rust-clippy/issues/1689 (as well as innumerable
Stackoverflow and rust-lang.org questions where dtolnay explains this to people)
for explanation.