### PR TITLE
pcp::types: Rename `Boolean` to `Count`

### DIFF
--- a/src/pcp.rs
+++ b/src/pcp.rs
@@ -19,12 +19,12 @@
 //! then the verification step will fail with high probability. For example:
 //!
 //! ```
-//! use prio::pcp::types::Boolean;
+//! use prio::pcp::types::Count;
 //! use prio::pcp::{decide, prove, query, Value};
 //! use prio::field::{random_vector, FieldElement, Field64};
 //!
-//! // The prover choose an input. In this case, the input is a boolean `false`.
-//! let input: Boolean<Field64> = Boolean::new(false);
+//! // The prover chooses a measurement.
+//! let input: Count<Field64> = Count::new(false);
 //!
 //! // The prover and verifier agree on "joint randomness" used to generate and
 //! // check the proof. The application needs to ensure that the prover
@@ -123,11 +123,11 @@ pub trait Value:
     /// of gadgets called by the circuit.
     ///
     /// ```
-    /// use prio::pcp::types::Boolean;
+    /// use prio::pcp::types::Count;
     /// use prio::pcp::Value;
     /// use prio::field::{random_vector, FieldElement, Field64};
     ///
-    /// let x: Boolean<Field64> = Boolean::new(false);
+    /// let x: Count<Field64> = Count::new(false);
     /// let joint_rand = random_vector(x.joint_rand_len()).unwrap();
     /// let v = x.valid(&mut x.gadget(), &joint_rand).unwrap();
     /// assert_eq!(v, Field64::zero());
@@ -672,7 +672,7 @@ mod tests {
     use super::*;
     use crate::field::{random_vector, split_vector, Field126};
     use crate::pcp::gadgets::{Mul, PolyEval};
-    use crate::pcp::types::Boolean;
+    use crate::pcp::types::Count;
     use crate::pcp::types::TypeError;
     use crate::polynomial::poly_range_check;
 
@@ -723,7 +723,7 @@ mod tests {
 
     #[test]
     fn test_decide() {
-        let x: Boolean<Field126> = Boolean::new(true);
+        let x: Count<Field126> = Count::new(true);
         let joint_rand = random_vector(x.joint_rand_len()).unwrap();
         let prove_rand = random_vector(x.prove_rand_len()).unwrap();
         let query_rand = random_vector(x.query_rand_len()).unwrap();

--- a/src/pcp/types.rs
+++ b/src/pcp/types.rs
@@ -18,14 +18,15 @@ pub enum TypeError {
     Instantiate(&'static str),
 }
 
-/// Values of this type encode a simple boolean (either `true` or `false`).
+/// The counter data type. Each measurement is `0` or `1` and the aggregate result is the sum of
+/// the measurements (i.e., the number of `1s`).
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Boolean<F: FieldElement> {
+pub struct Count<F: FieldElement> {
     data: Vec<F>,  // The encoded input
     range: Vec<F>, // A range check polynomial for [0, 2)
 }
 
-impl<F: FieldElement> Boolean<F> {
+impl<F: FieldElement> Count<F> {
     /// Encodes a boolean as a value of this type.
     pub fn new(b: bool) -> Self {
         Self {
@@ -38,7 +39,7 @@ impl<F: FieldElement> Boolean<F> {
     }
 }
 
-impl<F: FieldElement> Value for Boolean<F> {
+impl<F: FieldElement> Value for Count<F> {
     type Field = F;
     type Param = ();
 
@@ -96,7 +97,7 @@ impl<F: FieldElement> Value for Boolean<F> {
     fn param(&self) -> Self::Param {}
 }
 
-impl<F: FieldElement> TryFrom<((), &[F])> for Boolean<F> {
+impl<F: FieldElement> TryFrom<((), &[F])> for Count<F> {
     type Error = TypeError;
 
     fn try_from(val: ((), &[F])) -> Result<Self, TypeError> {
@@ -386,17 +387,17 @@ mod tests {
     }
 
     #[test]
-    fn test_boolean() {
+    fn test_count() {
         // Test PCP on valid input.
         pcp_validity_test(
-            &Boolean::<TestField>::new(true),
+            &Count::<TestField>::new(true),
             &ValidityTestCase {
                 expect_valid: true,
                 expected_proof_len: 9,
             },
         );
         pcp_validity_test(
-            &Boolean::<TestField>::new(false),
+            &Count::<TestField>::new(false),
             &ValidityTestCase {
                 expect_valid: true,
                 expected_proof_len: 9,
@@ -405,7 +406,7 @@ mod tests {
 
         // Test PCP on invalid input.
         pcp_validity_test(
-            &Boolean {
+            &Count {
                 data: vec![TestField::from(1337)],
                 range: poly_range_check(0, 2),
             },
@@ -416,7 +417,7 @@ mod tests {
         );
 
         // Try running the validity circuit on an input that's too short.
-        let malformed_x = Boolean::<TestField> {
+        let malformed_x = Count::<TestField> {
             data: vec![],
             range: poly_range_check(0, 2),
         };
@@ -425,7 +426,7 @@ mod tests {
             .unwrap_err();
 
         // Try running the validity circuit on an input that's too large.
-        let malformed_x = Boolean::<TestField> {
+        let malformed_x = Count::<TestField> {
             data: vec![TestField::zero(), TestField::zero()],
             range: poly_range_check(0, 2),
         };

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -386,13 +386,13 @@ mod tests {
     use super::*;
 
     use crate::field::Field64;
-    use crate::pcp::types::Boolean;
+    use crate::pcp::types::Count;
 
     #[test]
     fn test_prio3() {
         let suite = Suite::Blake3;
         const NUM_SHARES: usize = 23;
-        let input: Boolean<Field64> = Boolean::new(true);
+        let input: Count<Field64> = Count::new(true);
         let nonce = b"This is a good nonce.";
 
         // Client runs the input and proof distribution algorithms.
@@ -403,7 +403,7 @@ mod tests {
 
         // Aggregators receive their proof shares and broadcast their verifier messages.
         let (states, verifiers): (
-            Vec<VerifyState<Boolean<Field64>>>,
+            Vec<VerifyState<Count<Field64>>>,
             Vec<VerifyMessage<Field64>>,
         ) = verify_params
             .iter()


### PR DESCRIPTION
Based on #108 (merge that first!).
Partially closes #94.