### PR TITLE
pcp: Make TypeError a variant of PcpError

### DIFF
--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -11,7 +11,6 @@
 use std::convert::TryFrom;
 
 use crate::field::FieldElement;
-use crate::pcp::types::TypeError;
 use crate::pcp::PcpError;
 use crate::prng::{Prng, PrngError};
 use crate::vdaf::suite::{Key, KeyStream, SuiteError};
@@ -27,10 +26,6 @@ pub enum VdafError {
     /// PCP error.
     #[error("pcp error: {0}")]
     Pcp(#[from] PcpError),
-
-    /// Type error.
-    #[error("type error: {0}")]
-    Type(#[from] TypeError),
 
     /// PRNG error.
     #[error("prng error: {0}")]

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -392,7 +392,7 @@ mod tests {
     fn test_prio3() {
         let suite = Suite::Blake3;
         const NUM_SHARES: usize = 23;
-        let input: Count<Field64> = Count::new(true);
+        let input: Count<Field64> = Count::new(1).unwrap();
         let nonce = b"This is a good nonce.";
 
         // Client runs the input and proof distribution algorithms.


### PR DESCRIPTION
Based on #109.

While at it, update the constructor for `Count` to align with the aggregate result type.