### PR TITLE
add rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "1.56.1"
+components = [ "rustc", "rustfmt", "clippy" ]


### PR DESCRIPTION
Adds a
[`rust-toolchain.toml`](https://rust-lang.github.io/rustup/overrides.html)
to specify a required compiler version, ensuring that (1) we build with
a recent toolchain that supports features we need like const generics
and (2) we use a toolchain that includes the mitigation for
[CVE-2021-42574](https://rust-lang.github.io/rustup/overrides.html).