### PR TITLE
pcp: Clean up API for constructing input shares

### DIFF
--- a/src/pcp.rs
+++ b/src/pcp.rs
@@ -113,7 +113,7 @@ pub enum PcpError {
 
 /// A value of a certain type. Implementations of this trait specify an arithmetic circuit that
 /// determines whether a given value is valid.
-pub trait Value: Sized + PartialEq + Eq + Debug {
+pub trait Value: Sized + Eq + Debug {
     /// The finite field used for this type.
     type Field: FieldElement;
 

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -193,6 +193,9 @@ pub struct VerifyParam<V: Value> {
 
     /// The identity of the aggregator.
     pub aggregator_id: u8,
+
+    /// The number of aggregators.
+    pub num_shares: u8,
 }
 
 /// The setup algorithm of the VDAF that generates the verification parameter of each aggregator.
@@ -211,6 +214,7 @@ fn prio3_setup<V: Value>(
             value_param: value_param.clone(),
             query_rand_init: query_rand_init.clone(),
             aggregator_id,
+            num_shares,
         })
         .collect())
 }
@@ -260,8 +264,11 @@ pub fn prio3_start<V: Value>(
     let query_rand_seed = deriver.finish();
 
     let input_share_data: Vec<V::Field> = Vec::try_from(msg.input_share)?;
-    let mut input_share = V::try_from((verify_param.value_param.clone(), &input_share_data))?;
-    input_share.set_leader(verify_param.aggregator_id == 0);
+    let input_share = V::new_share(
+        input_share_data,
+        &verify_param.value_param,
+        verify_param.num_shares as usize,
+    )?;
 
     let proof_share_data: Vec<V::Field> = Vec::try_from(msg.proof_share)?;
     let proof_share = Proof::from(proof_share_data);


### PR DESCRIPTION
Based on #113.

* Remove the `TryFrom<(Value::Param, &'a [Value::Field])` trait bound
from `Value`.

* Remove `Value::set_leader()`, which was used to optionally specialize
the validity circuit depending on who owns the share (a leader or
helper).

* Add `Value::new_share()` method, which takes input the raw input
share, type parameters, and the total number of shares. The total number
of shares is used to optionally specialize the validity circuit.