### PR TITLE
pcp: Align API with draft-patton-cfrg-vdaf-00

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -92,7 +92,8 @@ pub trait FieldElement:
     /// The integer representation of the field element.
     type Integer: Copy
         + Debug
-        + PartialOrd
+        + Eq
+        + Ord
         + BitAnd<Output = <Self as FieldElement>::Integer>
         + Div<Output = <Self as FieldElement>::Integer>
         + Shr<Output = <Self as FieldElement>::Integer>

--- a/src/pcp/gadgets.rs
+++ b/src/pcp/gadgets.rs
@@ -102,6 +102,8 @@ impl<F: FieldElement> Gadget<F> for Mul<F> {
 }
 
 /// An arity-1 gadget that evaluates its input on some polynomial.
+//
+// TODO Make `poly` an array of length determined by a const generic.
 pub struct PolyEval<F: FieldElement> {
     poly: Vec<F>,
     /// Size of buffer for FFT operations.

--- a/src/pcp/types.rs
+++ b/src/pcp/types.rs
@@ -1,68 +1,66 @@
 // SPDX-License-Identifier: MPL-2.0
 
-//! A collection of data types.
+//! A collection of [`Type`](crate::pcp::Type) implementations.
 
 use crate::field::FieldElement;
 use crate::pcp::gadgets::{Mul, PolyEval};
-use crate::pcp::{Gadget, PcpError, Value, ValueParam};
+use crate::pcp::{Gadget, PcpError, Type};
 use crate::polynomial::poly_range_check;
 
 use std::convert::TryFrom;
 use std::mem::size_of;
 
 /// The counter data type. Each measurement is `0` or `1` and the aggregate result is the sum of
-/// the measurements (i.e., the number of `1s`).
+/// the measurements (i.e., the total number of `1s`).
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Count<F: FieldElement> {
-    data: Vec<F>,  // The encoded input
-    range: Vec<F>, // A range check polynomial for [0, 2)
+pub struct Count<F> {
+    range_checker: Vec<F>,
 }
 
 impl<F: FieldElement> Count<F> {
-    /// Construct a new counter.
-    pub fn new(value: u64) -> Result<Self, PcpError> {
-        Ok(Self {
-            range: poly_range_check(0, 2),
-            data: vec![match value {
-                1 => F::one(),
-                0 => F::zero(),
-                _ => {
-                    return Err(PcpError::Value("Count value must be 0 or 1".to_string()));
-                }
-            }],
-        })
+    /// Return a new [`Count`] type instance.
+    pub fn new() -> Self {
+        Self {
+            range_checker: poly_range_check(0, 2),
+        }
     }
 }
 
-impl<F: FieldElement> Value for Count<F> {
-    type Field = F;
-    type Param = CountValueParam;
-
-    fn new_share(
-        data: Vec<F>,
-        _param: &CountValueParam,
-        _num_shares: usize,
-    ) -> Result<Self, PcpError> {
-        Ok(Self {
-            data,
-            range: poly_range_check(0, 2),
-        })
+impl<F: FieldElement> Default for Count<F> {
+    fn default() -> Self {
+        Self::new()
     }
+}
 
-    fn valid(&self, g: &mut Vec<Box<dyn Gadget<F>>>, rand: &[F]) -> Result<F, PcpError> {
-        valid_call_check(self, rand)?;
+impl<F: FieldElement> Type for Count<F> {
+    type Measurement = F::Integer;
+    type Field = F;
 
-        if self.data.len() != 1 {
-            return Err(PcpError::Valid(format!(
-                "unexpected input length: got {}; want {}",
-                self.data.len(),
-                1
-            )));
+    fn encode(&self, value: &F::Integer) -> Result<Vec<F>, PcpError> {
+        let max = F::Integer::try_from(1).unwrap();
+        if *value > max {
+            return Err(PcpError::Encode("Count value must be 0 or 1".to_string()));
         }
 
-        let mut inp = [self.data[0], self.data[0]];
-        let mut v = self.range[0];
-        for c in &self.range[1..] {
+        Ok(vec![F::from(*value)])
+    }
+
+    fn gadget(&self) -> Vec<Box<dyn Gadget<F>>> {
+        vec![Box::new(Mul::new(2))]
+    }
+
+    fn valid(
+        &self,
+        g: &mut Vec<Box<dyn Gadget<F>>>,
+        input: &[F],
+        joint_rand: &[F],
+        _num_shares: usize,
+    ) -> Result<F, PcpError> {
+        valid_call_check(self, input, joint_rand)?;
+
+        let mut inp = [input[0], input[0]];
+        let mut v = self.range_checker[0];
+        for c in &self.range_checker[1..] {
             v += *c * inp[0];
             inp[0] = g[0].call(&inp)?;
         }
@@ -70,28 +68,11 @@ impl<F: FieldElement> Value for Count<F> {
         Ok(v)
     }
 
-    fn as_slice(&self) -> &[F] {
-        &self.data
+    fn truncate(&self, input: &[F]) -> Result<Vec<F>, PcpError> {
+        truncate_call_check(self, input)?;
+        Ok(input.to_vec())
     }
 
-    fn gadget(&self) -> Vec<Box<dyn Gadget<F>>> {
-        vec![Box::new(Mul::new(2))]
-    }
-
-    fn param(&self) -> CountValueParam {
-        CountValueParam()
-    }
-
-    fn into_output(self) -> Vec<F> {
-        self.data
-    }
-}
-
-/// Parameters for the [`Count`] type.
-#[derive(Clone, Debug)]
-pub struct CountValueParam();
-
-impl ValueParam for CountValueParam {
     fn input_len(&self) -> usize {
         1
     }
@@ -123,120 +104,97 @@ impl ValueParam for CountValueParam {
 ///
 /// [BBCG+19]: https://ia.cr/2019/188
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Sum<F: FieldElement> {
-    data: Vec<F>,
+pub struct Sum<F> {
+    bits: usize,
     range_checker: Vec<F>,
 }
 
 impl<F: FieldElement> Sum<F> {
-    /// Constructs a new summand. The value of `summand` must be in `[0, 2^bits)`.
-    pub fn new(summand: u64, bits: u32) -> Result<Self, PcpError> {
-        let summand = usize::try_from(summand).unwrap();
-        let bits = usize::try_from(bits).unwrap();
-
-        if bits > (size_of::<F::Integer>() << 3) {
-            return Err(PcpError::Value(
-                "bits exceeds bit length of the field's integer representation".to_string(),
-            ));
+    /// Return a new [`Sum`] type parameter. Each value of this type is an integer in range `[0,
+    /// 2^bits)`.
+    pub fn new(bits: usize) -> Result<Self, PcpError> {
+        let max_bits = size_of::<F::Integer>() << 3;
+        if bits > max_bits {
+            return Err(PcpError::Encode(format!(
+                "bits ({}) exceeds bit length of the field's integer representation ({})",
+                bits, max_bits,
+            )));
         }
 
-        let int = F::Integer::try_from(summand).map_err(|err| {
-            PcpError::Value(format!("failed to convert summand to field: {:?}", err))
-        })?;
+        Ok(Self {
+            bits,
+            range_checker: poly_range_check(0, 2),
+        })
+    }
+}
 
-        let max = F::Integer::try_from(1 << bits).unwrap();
-        if int >= max {
-            return Err(PcpError::Value(
+impl<F: FieldElement> Type for Sum<F> {
+    type Measurement = F::Integer;
+    type Field = F;
+
+    fn encode(&self, summand: &F::Integer) -> Result<Vec<F>, PcpError> {
+        let max = F::Integer::try_from(1 << self.bits).unwrap();
+        if *summand >= max {
+            return Err(PcpError::Encode(
                 "value of summand exceeds bit length".to_string(),
             ));
         }
 
         let one = F::Integer::try_from(1).unwrap();
-        let mut data: Vec<F> = Vec::with_capacity(bits);
-        for l in 0..bits {
+        let mut encoded: Vec<F> = Vec::with_capacity(self.bits);
+        for l in 0..self.bits {
             let l = F::Integer::try_from(l).unwrap();
-            let w = F::from((int >> l) & one);
-            data.push(w);
+            let w = F::from((*summand >> l) & one);
+            encoded.push(w);
         }
 
-        Ok(Self {
-            data,
-            range_checker: poly_range_check(0, 2),
-        })
-    }
-}
-
-impl<F: FieldElement> Value for Sum<F> {
-    type Field = F;
-    type Param = SumValueParam;
-
-    fn new_share(
-        data: Vec<F>,
-        param: &SumValueParam,
-        _num_shares: usize,
-    ) -> Result<Self, PcpError> {
-        if data.len() != param.0 as usize {
-            return Err(PcpError::Value(
-                "data length does not match bit length".to_string(),
-            ));
-        }
-
-        Ok(Self {
-            data,
-            range_checker: poly_range_check(0, 2),
-        })
-    }
-
-    fn valid(&self, g: &mut Vec<Box<dyn Gadget<F>>>, rand: &[F]) -> Result<F, PcpError> {
-        valid_call_check(self, rand)?;
-
-        // Check that each element of `data` is a 0 or 1.
-        let mut range_check = F::zero();
-        let mut r = rand[0];
-        for chunk in self.data.chunks(1) {
-            range_check += r * g[0].call(chunk)?;
-            r *= rand[0];
-        }
-
-        Ok(range_check)
-    }
-
-    fn as_slice(&self) -> &[F] {
-        &self.data
+        Ok(encoded)
     }
 
     fn gadget(&self) -> Vec<Box<dyn Gadget<F>>> {
         vec![Box::new(PolyEval::new(
             self.range_checker.clone(),
-            self.data.len(),
+            self.bits,
         ))]
     }
 
-    fn param(&self) -> SumValueParam {
-        SumValueParam(self.data.len())
+    fn valid(
+        &self,
+        g: &mut Vec<Box<dyn Gadget<F>>>,
+        input: &[F],
+        joint_rand: &[F],
+        _num_shares: usize,
+    ) -> Result<F, PcpError> {
+        valid_call_check(self, input, joint_rand)?;
+
+        // Check that each element of `data` is a 0 or 1.
+        let mut range_check = F::zero();
+        let mut r = joint_rand[0];
+        for chunk in input.chunks(1) {
+            range_check += r * g[0].call(chunk)?;
+            r *= joint_rand[0];
+        }
+
+        Ok(range_check)
     }
 
-    fn into_output(self) -> Vec<F> {
+    fn truncate(&self, input: &[F]) -> Result<Vec<F>, PcpError> {
+        truncate_call_check(self, input)?;
+
         let mut decoded = F::zero();
-        for (l, bit) in self.data.iter().enumerate() {
+        for (l, bit) in input.iter().enumerate() {
             let w = F::from(F::Integer::try_from(1 << l).unwrap());
             decoded += w * *bit;
         }
-        vec![decoded]
+        Ok(vec![decoded])
     }
-}
 
-/// Parameters for the [`Sum`] type.
-#[derive(Clone, Debug)]
-pub struct SumValueParam(usize);
-
-impl ValueParam for SumValueParam {
     fn input_len(&self) -> usize {
-        self.0
+        self.bits
     }
 
     fn proof_len(&self) -> usize {
-        2 * ((1 + self.0).next_power_of_two() - 1) + 2
+        2 * ((1 + self.bits).next_power_of_two() - 1) + 2
     }
 
     fn verifier_len(&self) -> usize {
@@ -259,19 +217,16 @@ impl ValueParam for SumValueParam {
 /// The histogram type. Each measurement is a non-negative integer and the aggregate is a histogram
 /// approximating the distribution of the measurements.
 #[derive(Clone, Debug, PartialEq, Eq)]
-pub struct Histogram<F> {
-    data: Vec<F>,
+pub struct Histogram<F: FieldElement> {
+    buckets: Vec<F::Integer>,
     range_checker: Vec<F>,
-    sum_check_share: F,
 }
 
 impl<F: FieldElement> Histogram<F> {
-    /// Constructs a new histogram input. The values of `buckets` must be strictly increasing.
-    pub fn new(measurement: u64, buckets: &[u64]) -> Result<Self, PcpError> {
-        let mut data = vec![F::zero(); buckets.len() + 1];
-
+    /// Return a new [`Histogram`] type with the given buckets.
+    pub fn new(buckets: Vec<F::Integer>) -> Result<Self, PcpError> {
         if buckets.len() >= u32::MAX as usize {
-            return Err(PcpError::Value(
+            return Err(PcpError::Encode(
                 "invalid buckets: number of buckets exceeds maximum permitted".to_string(),
             ));
         }
@@ -279,104 +234,82 @@ impl<F: FieldElement> Histogram<F> {
         if !buckets.is_empty() {
             for i in 0..buckets.len() - 1 {
                 if buckets[i + 1] <= buckets[i] {
-                    return Err(PcpError::Value(
+                    return Err(PcpError::Encode(
                         "invalid buckets: out-of-order boundary".to_string(),
                     ));
                 }
             }
         }
 
-        let bucket = match buckets.binary_search(&measurement) {
+        Ok(Self {
+            buckets,
+            range_checker: poly_range_check(0, 2),
+        })
+    }
+}
+
+impl<F: FieldElement> Type for Histogram<F> {
+    type Measurement = F::Integer;
+    type Field = F;
+
+    fn encode(&self, measurement: &F::Integer) -> Result<Vec<F>, PcpError> {
+        let mut data = vec![F::zero(); self.buckets.len() + 1];
+
+        let bucket = match self.buckets.binary_search(measurement) {
             Ok(i) => i,  // on a bucket boundary
             Err(i) => i, // smaller than the i-th bucket boundary
         };
 
         data[bucket] = F::one();
-
-        Ok(Self {
-            data,
-            range_checker: poly_range_check(0, 2),
-            sum_check_share: F::one(),
-        })
-    }
-}
-
-impl<F: FieldElement> Value for Histogram<F> {
-    type Field = F;
-    type Param = HistogramValueParam;
-
-    fn new_share(
-        data: Vec<F>,
-        param: &HistogramValueParam,
-        num_shares: usize,
-    ) -> Result<Self, PcpError> {
-        if data.len() != param.0 {
-            return Err(PcpError::Value(
-                "data length does not match buckets".to_string(),
-            ));
-        }
-
-        let sum_check_share = F::one() / F::from(F::Integer::try_from(num_shares).unwrap());
-        Ok(Self {
-            data: data.to_vec(),
-            range_checker: poly_range_check(0, 2),
-            sum_check_share,
-        })
-    }
-
-    fn valid(&self, g: &mut Vec<Box<dyn Gadget<F>>>, rand: &[F]) -> Result<F, PcpError> {
-        valid_call_check(self, rand)?;
-
-        // Check that each element of `data` is a 0 or 1.
-        let mut range_check = F::zero();
-        let mut r = rand[0];
-        for chunk in self.data.chunks(1) {
-            range_check += r * g[0].call(chunk)?;
-            r *= rand[0];
-        }
-
-        // Check that the elements of `data` sum to 1.
-        let mut sum_check = -self.sum_check_share;
-        for val in self.data.iter() {
-            sum_check += *val;
-        }
-
-        // Take a random linear combination of both checks.
-        let out = rand[1] * range_check + (rand[1] * rand[1]) * sum_check;
-        Ok(out)
-    }
-
-    fn as_slice(&self) -> &[F] {
-        &self.data
+        Ok(data)
     }
 
     fn gadget(&self) -> Vec<Box<dyn Gadget<F>>> {
         vec![Box::new(PolyEval::new(
-            self.range_checker.clone(),
-            self.data.len(),
+            self.range_checker.to_vec(),
+            self.input_len(),
         ))]
     }
 
-    fn param(&self) -> HistogramValueParam {
-        HistogramValueParam(self.data.len())
+    fn valid(
+        &self,
+        g: &mut Vec<Box<dyn Gadget<F>>>,
+        input: &[F],
+        joint_rand: &[F],
+        num_shares: usize,
+    ) -> Result<F, PcpError> {
+        valid_call_check(self, input, joint_rand)?;
+
+        // Check that each element of `data` is a 0 or 1.
+        let mut range_check = F::zero();
+        let mut r = joint_rand[0];
+        for chunk in input.chunks(1) {
+            range_check += r * g[0].call(chunk)?;
+            r *= joint_rand[0];
+        }
+
+        // Check that the elements of `data` sum to 1.
+        let mut sum_check = -(F::one() / F::from(F::Integer::try_from(num_shares).unwrap()));
+        for val in input.iter() {
+            sum_check += *val;
+        }
+
+        // Take a random linear combination of both checks.
+        let out = joint_rand[1] * range_check + (joint_rand[1] * joint_rand[1]) * sum_check;
+        Ok(out)
     }
 
-    fn into_output(self) -> Vec<F> {
-        self.data
+    fn truncate(&self, input: &[F]) -> Result<Vec<F>, PcpError> {
+        truncate_call_check(self, input)?;
+        Ok(input.to_vec())
     }
-}
 
-/// Parameters for the [`Histogram`] type.
-#[derive(Clone, Debug)]
-pub struct HistogramValueParam(usize);
-
-impl ValueParam for HistogramValueParam {
     fn input_len(&self) -> usize {
-        self.0
+        self.buckets.len() + 1
     }
 
     fn proof_len(&self) -> usize {
-        2 * ((1 + self.0).next_power_of_two() - 1) + 2
+        2 * ((1 + self.input_len()).next_power_of_two() - 1) + 2
     }
 
     fn verifier_len(&self) -> usize {
@@ -396,22 +329,36 @@ impl ValueParam for HistogramValueParam {
     }
 }
 
-fn valid_call_check<V: Value>(input: &V, joint_rand: &[V::Field]) -> Result<(), PcpError> {
-    let param = input.param();
-
-    if input.as_slice().len() != param.input_len() {
+fn valid_call_check<T: Type>(
+    typ: &T,
+    input: &[T::Field],
+    joint_rand: &[T::Field],
+) -> Result<(), PcpError> {
+    if input.len() != typ.input_len() {
         return Err(PcpError::Valid(format!(
             "unexpected input length: got {}; want {}",
-            input.as_slice().len(),
-            param.input_len(),
+            input.len(),
+            typ.input_len(),
         )));
     }
 
-    if joint_rand.len() != param.joint_rand_len() {
+    if joint_rand.len() != typ.joint_rand_len() {
         return Err(PcpError::Valid(format!(
             "unexpected joint randomness length: got {}; want {}",
             joint_rand.len(),
-            param.joint_rand_len()
+            typ.joint_rand_len()
+        )));
+    }
+
+    Ok(())
+}
+
+fn truncate_call_check<T: Type>(typ: &T, input: &[T::Field]) -> Result<(), PcpError> {
+    if input.len() != typ.input_len() {
+        return Err(PcpError::Truncate(format!(
+            "Unexpected input length: got {}; want {}",
+            input.len(),
+            typ.input_len()
         )));
     }
 
@@ -422,7 +369,6 @@ fn valid_call_check<V: Value>(input: &V, joint_rand: &[V::Field]) -> Result<(), 
 mod tests {
     use super::*;
     use crate::field::{random_vector, split_vector, Field64 as TestField};
-    use crate::pcp::{decide, prove, query, Proof, Value, Verifier};
 
     // Number of shares to split input and proofs into in `pcp_test`.
     const NUM_SHARES: usize = 3;
@@ -434,12 +380,14 @@ mod tests {
 
     #[test]
     fn test_count() {
+        let count: Count<TestField> = Count::new();
         let zero = TestField::zero();
         let one = TestField::one();
 
         // Test PCP on valid input.
         pcp_validity_test(
-            &Count::<TestField>::new(1).unwrap(),
+            &count,
+            &count.encode(&1).unwrap(),
             &ValidityTestCase::<TestField> {
                 expect_valid: true,
                 expected_output: Some(vec![one]),
@@ -448,7 +396,8 @@ mod tests {
         .unwrap();
 
         pcp_validity_test(
-            &Count::<TestField>::new(0).unwrap(),
+            &count,
+            &count.encode(&0).unwrap(),
             &ValidityTestCase::<TestField> {
                 expect_valid: true,
                 expected_output: Some(vec![zero]),
@@ -458,10 +407,8 @@ mod tests {
 
         // Test PCP on invalid input.
         pcp_validity_test(
-            &Count {
-                data: vec![TestField::from(1337)],
-                range: poly_range_check(0, 2),
-            },
+            &count,
+            &[TestField::from(1337)],
             &ValidityTestCase::<TestField> {
                 expect_valid: false,
                 expected_output: None,
@@ -470,21 +417,9 @@ mod tests {
         .unwrap();
 
         // Try running the validity circuit on an input that's too short.
-        let malformed_x = Count::<TestField> {
-            data: vec![],
-            range: poly_range_check(0, 2),
-        };
-        malformed_x
-            .valid(&mut malformed_x.gadget(), &[])
-            .unwrap_err();
-
-        // Try running the validity circuit on an input that's too large.
-        let malformed_x = Count::<TestField> {
-            data: vec![TestField::zero(), TestField::zero()],
-            range: poly_range_check(0, 2),
-        };
-        malformed_x
-            .valid(&mut malformed_x.gadget(), &[])
+        count.valid(&mut count.gadget(), &[], &[], 1).unwrap_err();
+        count
+            .valid(&mut count.gadget(), &[1.into(), 2.into()], &[], 1)
             .unwrap_err();
     }
 
@@ -494,9 +429,13 @@ mod tests {
         let one = TestField::one();
         let nine = TestField::from(9);
 
+        // TODO(cjpatton) Try encoding invalid measurements.
+
         // Test PCP on valid input.
+        let sum = Sum::new(11).unwrap();
         pcp_validity_test(
-            &Sum::<TestField>::new(1337, 11).unwrap(),
+            &sum,
+            &sum.encode(&1337).unwrap(),
             &ValidityTestCase {
                 expect_valid: true,
                 expected_output: Some(vec![TestField::from(1337)]),
@@ -505,10 +444,8 @@ mod tests {
         .unwrap();
 
         pcp_validity_test(
-            &Sum::<TestField> {
-                data: vec![],
-                range_checker: poly_range_check(0, 2),
-            },
+            &Sum::new(0).unwrap(),
+            &[],
             &ValidityTestCase::<TestField> {
                 expect_valid: true,
                 expected_output: Some(vec![zero]),
@@ -517,10 +454,8 @@ mod tests {
         .unwrap();
 
         pcp_validity_test(
-            &Sum::<TestField> {
-                data: vec![one, zero],
-                range_checker: poly_range_check(0, 2),
-            },
+            &Sum::new(2).unwrap(),
+            &[one, zero],
             &ValidityTestCase {
                 expect_valid: true,
                 expected_output: Some(vec![one]),
@@ -529,10 +464,8 @@ mod tests {
         .unwrap();
 
         pcp_validity_test(
-            &Sum::<TestField> {
-                data: vec![one, zero, one, one, zero, one, one, one, zero],
-                range_checker: poly_range_check(0, 2),
-            },
+            &Sum::new(9).unwrap(),
+            &[one, zero, one, one, zero, one, one, one, zero],
             &ValidityTestCase::<TestField> {
                 expect_valid: true,
                 expected_output: Some(vec![TestField::from(237)]),
@@ -542,10 +475,8 @@ mod tests {
 
         // Test PCP on invalid input.
         pcp_validity_test(
-            &Sum::<TestField> {
-                data: vec![one, nine, zero],
-                range_checker: poly_range_check(0, 2),
-            },
+            &Sum::new(3).unwrap(),
+            &[one, nine, zero],
             &ValidityTestCase::<TestField> {
                 expect_valid: false,
                 expected_output: None,
@@ -554,10 +485,8 @@ mod tests {
         .unwrap();
 
         pcp_validity_test(
-            &Sum::<TestField> {
-                data: vec![zero, zero, zero, zero, nine],
-                range_checker: poly_range_check(0, 2),
-            },
+            &Sum::new(5).unwrap(),
+            &[zero, zero, zero, zero, nine],
             &ValidityTestCase::<TestField> {
                 expect_valid: false,
                 expected_output: None,
@@ -568,33 +497,25 @@ mod tests {
 
     #[test]
     fn test_histogram() {
+        let hist = Histogram::new(vec![10, 20]).unwrap();
         let zero = TestField::zero();
         let one = TestField::one();
         let nine = TestField::from(9);
-        let buckets = [10, 20];
 
-        let input: Histogram<TestField> = Histogram::new(7, &buckets).unwrap();
-        assert_eq!(input.data, &[one, zero, zero]);
-
-        let input: Histogram<TestField> = Histogram::new(10, &buckets).unwrap();
-        assert_eq!(input.data, &[one, zero, zero]);
-
-        let input: Histogram<TestField> = Histogram::new(17, &buckets).unwrap();
-        assert_eq!(input.data, &[zero, one, zero]);
-
-        let input: Histogram<TestField> = Histogram::new(20, &buckets).unwrap();
-        assert_eq!(input.data, &[zero, one, zero]);
-
-        let input: Histogram<TestField> = Histogram::new(27, &buckets).unwrap();
-        assert_eq!(input.data, &[zero, zero, one]);
+        assert_eq!(&hist.encode(&7).unwrap(), &[one, zero, zero]);
+        assert_eq!(&hist.encode(&10).unwrap(), &[one, zero, zero]);
+        assert_eq!(&hist.encode(&17).unwrap(), &[zero, one, zero]);
+        assert_eq!(&hist.encode(&20).unwrap(), &[zero, one, zero]);
+        assert_eq!(&hist.encode(&27).unwrap(), &[zero, zero, one]);
 
         // Invalid bucket boundaries.
-        Histogram::<TestField>::new(27, &[10, 0]).unwrap_err();
-        Histogram::<TestField>::new(27, &[10, 10]).unwrap_err();
+        Histogram::<TestField>::new(vec![10, 0]).unwrap_err();
+        Histogram::<TestField>::new(vec![10, 10]).unwrap_err();
 
         // Test valid inputs.
         pcp_validity_test(
-            &Histogram::<TestField>::new(0, &buckets).unwrap(),
+            &hist,
+            &hist.encode(&0).unwrap(),
             &ValidityTestCase::<TestField> {
                 expect_valid: true,
                 expected_output: Some(vec![one, zero, zero]),
@@ -603,7 +524,8 @@ mod tests {
         .unwrap();
 
         pcp_validity_test(
-            &Histogram::<TestField>::new(17, &buckets).unwrap(),
+            &hist,
+            &hist.encode(&17).unwrap(),
             &ValidityTestCase::<TestField> {
                 expect_valid: true,
                 expected_output: Some(vec![zero, one, zero]),
@@ -612,7 +534,8 @@ mod tests {
         .unwrap();
 
         pcp_validity_test(
-            &Histogram::<TestField>::new(1337, &buckets).unwrap(),
+            &hist,
+            &hist.encode(&1337).unwrap(),
             &ValidityTestCase::<TestField> {
                 expect_valid: true,
                 expected_output: Some(vec![zero, zero, one]),
@@ -622,11 +545,8 @@ mod tests {
 
         // Test invalid inputs.
         pcp_validity_test(
-            &Histogram::<TestField> {
-                data: vec![zero, zero, nine],
-                range_checker: poly_range_check(0, 2),
-                sum_check_share: one,
-            },
+            &hist,
+            &[zero, zero, nine],
             &ValidityTestCase::<TestField> {
                 expect_valid: false,
                 expected_output: None,
@@ -635,11 +555,8 @@ mod tests {
         .unwrap();
 
         pcp_validity_test(
-            &Histogram::<TestField> {
-                data: vec![zero, one, one],
-                range_checker: poly_range_check(0, 2),
-                sum_check_share: one,
-            },
+            &hist,
+            &[zero, one, one],
             &ValidityTestCase::<TestField> {
                 expect_valid: false,
                 expected_output: None,
@@ -648,11 +565,8 @@ mod tests {
         .unwrap();
 
         pcp_validity_test(
-            &Histogram::<TestField> {
-                data: vec![one, one, one],
-                range_checker: poly_range_check(0, 2),
-                sum_check_share: one,
-            },
+            &hist,
+            &[one, one, one],
             &ValidityTestCase::<TestField> {
                 expect_valid: false,
                 expected_output: None,
@@ -661,11 +575,8 @@ mod tests {
         .unwrap();
 
         pcp_validity_test(
-            &Histogram::<TestField> {
-                data: vec![zero, zero, zero],
-                range_checker: poly_range_check(0, 2),
-                sum_check_share: one,
-            },
+            &hist,
+            &[zero, zero, zero],
             &ValidityTestCase::<TestField> {
                 expect_valid: false,
                 expected_output: None,
@@ -674,52 +585,42 @@ mod tests {
         .unwrap();
     }
 
-    fn pcp_validity_test<V: Value>(
-        input: &V,
-        t: &ValidityTestCase<V::Field>,
+    fn pcp_validity_test<T: Type>(
+        typ: &T,
+        input: &[T::Field],
+        t: &ValidityTestCase<T::Field>,
     ) -> Result<(), PcpError> {
-        let mut gadgets = input.gadget();
-        let param = input.param();
+        let mut gadgets = typ.gadget();
 
-        if input.as_slice().len() != param.input_len() {
+        if input.len() != typ.input_len() {
             return Err(PcpError::Test(format!(
                 "unexpected input length: got {}; want {}",
-                input.as_slice().len(),
-                param.input_len()
+                input.len(),
+                typ.input_len()
             )));
         }
 
-        if param.query_rand_len() != gadgets.len() {
+        if typ.query_rand_len() != gadgets.len() {
             return Err(PcpError::Test(format!(
                 "query rand length: got {}; want {}",
-                param.query_rand_len(),
+                typ.query_rand_len(),
                 gadgets.len()
             )));
         }
 
-        // Ensure that the input can be constructed from its parameters and its encoding as a
-        // sequence of field elements.
-        let got = &V::new_share(input.as_slice().to_vec(), &input.param(), 1)?;
-        if got != input {
-            return Err(PcpError::Test(format!(
-                "input constructed from data and param does not match input: got {:?}; want {:?}",
-                got, input
-            )));
-        }
-
-        let joint_rand = random_vector(param.joint_rand_len()).unwrap();
-        let prove_rand = random_vector(param.prove_rand_len()).unwrap();
-        let query_rand = random_vector(param.query_rand_len()).unwrap();
+        let joint_rand = random_vector(typ.joint_rand_len()).unwrap();
+        let prove_rand = random_vector(typ.prove_rand_len()).unwrap();
+        let query_rand = random_vector(typ.query_rand_len()).unwrap();
 
         // Run the validity circuit.
-        let v = input.valid(&mut gadgets, &joint_rand)?;
-        if v != V::Field::zero() && t.expect_valid {
+        let v = typ.valid(&mut gadgets, input, &joint_rand, 1)?;
+        if v != T::Field::zero() && t.expect_valid {
             return Err(PcpError::Test(format!(
                 "expected valid input: valid() returned {}",
                 v
             )));
         }
-        if v == V::Field::zero() && !t.expect_valid {
+        if v == T::Field::zero() && !t.expect_valid {
             return Err(PcpError::Test(format!(
                 "expected invalid input: valid() returned {}",
                 v
@@ -727,27 +628,27 @@ mod tests {
         }
 
         // Generate the proof.
-        let proof = prove(input, &prove_rand, &joint_rand)?;
-        if proof.as_slice().len() != param.proof_len() {
+        let proof = typ.prove(input, &prove_rand, &joint_rand)?;
+        if proof.len() != typ.proof_len() {
             return Err(PcpError::Test(format!(
                 "unexpected proof length: got {}; want {}",
-                proof.as_slice().len(),
-                param.proof_len()
+                proof.len(),
+                typ.proof_len()
             )));
         }
 
         // Query the proof.
-        let verifier = query(input, &proof, &query_rand, &joint_rand)?;
-        if verifier.as_slice().len() != param.verifier_len() {
+        let verifier = typ.query(input, &proof, &query_rand, &joint_rand, 1)?;
+        if verifier.len() != typ.verifier_len() {
             return Err(PcpError::Test(format!(
                 "unexpected verifier length: got {}; want {}",
-                verifier.as_slice().len(),
-                param.verifier_len()
+                verifier.len(),
+                typ.verifier_len()
             )));
         }
 
         // Decide if the input is valid.
-        let res = decide(input, &verifier)?;
+        let res = typ.decide(&verifier)?;
         if res != t.expect_valid {
             return Err(PcpError::Test(format!(
                 "decision is {}; want {}",
@@ -756,29 +657,36 @@ mod tests {
         }
 
         // Run distributed PCP.
-        let input_shares: Vec<V> = split_vector(input.as_slice(), NUM_SHARES)
+        let input_shares: Vec<Vec<T::Field>> = split_vector(input, NUM_SHARES)
             .unwrap()
             .into_iter()
-            .map(|data| V::new_share(data.clone(), &input.param(), NUM_SHARES).unwrap())
             .collect();
 
-        let proof_shares: Vec<Proof<V::Field>> = split_vector(proof.as_slice(), NUM_SHARES)
+        let proof_shares: Vec<Vec<T::Field>> = split_vector(&proof, NUM_SHARES)
             .unwrap()
             .into_iter()
-            .map(Proof::from)
             .collect();
 
-        let verifier: Verifier<V::Field> = (0..NUM_SHARES)
-            .map(|i| query(&input_shares[i], &proof_shares[i], &query_rand, &joint_rand).unwrap())
+        let verifier: Vec<T::Field> = (0..NUM_SHARES)
+            .map(|i| {
+                typ.query(
+                    &input_shares[i],
+                    &proof_shares[i],
+                    &query_rand,
+                    &joint_rand,
+                    NUM_SHARES,
+                )
+                .unwrap()
+            })
             .reduce(|mut left, right| {
-                for (x, y) in left.data.iter_mut().zip(right.data.iter()) {
+                for (x, y) in left.iter_mut().zip(right.iter()) {
                     *x += *y;
                 }
-                Verifier { data: left.data }
+                left
             })
             .unwrap();
 
-        let res = decide(&input_shares[0], &verifier)?;
+        let res = typ.decide(&verifier)?;
         if res != t.expect_valid {
             return Err(PcpError::Test(format!(
                 "distributed decision is {}; want {}",
@@ -787,11 +695,11 @@ mod tests {
         }
 
         // Try verifying various proof mutants.
-        for i in 0..proof.as_slice().len() {
+        for i in 0..proof.len() {
             let mut mutated_proof = proof.clone();
-            mutated_proof.data[i] += V::Field::one();
-            let verifier = query(input, &mutated_proof, &query_rand, &joint_rand)?;
-            if decide(input, &verifier)? {
+            mutated_proof[i] += T::Field::one();
+            let verifier = typ.query(input, &mutated_proof, &query_rand, &joint_rand, 1)?;
+            if typ.decide(&verifier)? {
                 return Err(PcpError::Test(format!(
                     "decision for proof mutant {} is {}; want {}",
                     i, true, false,
@@ -801,8 +709,11 @@ mod tests {
 
         // Try verifying a proof that is too short.
         let mut mutated_proof = proof.clone();
-        mutated_proof.data.truncate(gadgets[0].arity() - 1);
-        if !query(input, &mutated_proof, &query_rand, &joint_rand).is_err() {
+        mutated_proof.truncate(gadgets[0].arity() - 1);
+        if !typ
+            .query(input, &mutated_proof, &query_rand, &joint_rand, 1)
+            .is_err()
+        {
             return Err(PcpError::Test(format!(
                 "query on short proof succeeded; want failure",
             )));
@@ -810,15 +721,18 @@ mod tests {
 
         // Try verifying a proof that is too long.
         let mut mutated_proof = proof.clone();
-        mutated_proof.data.extend_from_slice(&[V::Field::one(); 17]);
-        if !query(input, &mutated_proof, &query_rand, &joint_rand).is_err() {
+        mutated_proof.extend_from_slice(&[T::Field::one(); 17]);
+        if !typ
+            .query(input, &mutated_proof, &query_rand, &joint_rand, 1)
+            .is_err()
+        {
             return Err(PcpError::Test(format!(
                 "query on long proof succeeded; want failure",
             )));
         }
 
         if let Some(ref want) = t.expected_output {
-            let got = input.clone().into_output();
+            let got = typ.truncate(input)?;
             if &got != want {
                 return Err(PcpError::Test(format!(
                     "unexpected output: got {:?}; want {:?}",


### PR DESCRIPTION
Replace `Value` with trait `Type`, implementations of which provide the
FLP functionality described in the spec. In particular, each `Type`
implementation specifies how measurements are encoded and validated. The
FLP system is now implemented as a set of derived methods on a generic
`Type`. However, the type itself does not subsume the input that is
validated.
    
Shifting the API boundary this way makes it easier to integrate the FLP
into `prio3`.
