### PR TITLE
pcp: Make measurement types generic

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -92,7 +92,7 @@ pub trait FieldElement:
     /// The integer representation of the field element.
     type Integer: Copy
         + Debug
-        + PartialOrd
+        + Ord
         + BitAnd<Output = <Self as FieldElement>::Integer>
         + Div<Output = <Self as FieldElement>::Integer>
         + Shr<Output = <Self as FieldElement>::Integer>


### PR DESCRIPTION
Each of `Count`, `Sum`, and `Histogram` have `F: FieldElement` as a
generic parameter. This makes the constructor for each of these values
take a `F::Integer` as the measurement.