### PR TITLE
vdaf: Update associated types of `PrepareStep`

### DIFF
--- a/src/vdaf/hits.rs
+++ b/src/vdaf/hits.rs
@@ -475,8 +475,7 @@ enum SketchState {
 }
 
 impl<F: FieldElement> PrepareStep<Vec<F>> for HitsPrepareStep<F> {
-    type Input = Vec<F>;
-    type Output = Vec<F>;
+    type Message = Vec<F>;
 
     fn step<M: IntoIterator<Item = Vec<F>>>(
         mut self,


### PR DESCRIPTION
Associated types `Input` and `Output` define the input type and output
type of each round respectively. It is impossible for these types to be
different, however, since the type of outputs in a given needs to match
the input types of the next round. Thus this commit simplifies the type
by merging `Input` and `Output` into a single `Message` type. Each round
having a different message type is expressed using an `enum`.