### PR TITLE
vdaf: Align prio3 with the VDAF traits

### DIFF
--- a/src/pcp.rs
+++ b/src/pcp.rs
@@ -189,7 +189,10 @@ pub trait Type: Sized + Eq + Clone + Debug {
     /// The length in field elements of the verifier message constructed by [`Self::query`].
     fn verifier_len(&self) -> usize;
 
-    /// The length in field elements of the joint random input.
+    /// The length of the truncated output (i.e., the output of [`Type::truncate`]).
+    fn output_len(&self) -> usize;
+
+    /// The length of the joint random input.
     fn joint_rand_len(&self) -> usize;
 
     /// The length in field elements of the random input consumed by the prover to generate a
@@ -779,6 +782,10 @@ mod tests {
             let poly = 1 + 1 /* gadget arity */;
 
             1 + mul + poly
+        }
+
+        fn output_len(&self) -> usize {
+            self.input_len()
         }
 
         fn joint_rand_len(&self) -> usize {

--- a/src/pcp/types.rs
+++ b/src/pcp/types.rs
@@ -85,6 +85,10 @@ impl<F: FieldElement> Type for Count<F> {
         4
     }
 
+    fn output_len(&self) -> usize {
+        self.input_len()
+    }
+
     fn joint_rand_len(&self) -> usize {
         0
     }
@@ -201,6 +205,10 @@ impl<F: FieldElement> Type for Sum<F> {
         3
     }
 
+    fn output_len(&self) -> usize {
+        1
+    }
+
     fn joint_rand_len(&self) -> usize {
         1
     }
@@ -314,6 +322,10 @@ impl<F: FieldElement> Type for Histogram<F> {
 
     fn verifier_len(&self) -> usize {
         3
+    }
+
+    fn output_len(&self) -> usize {
+        self.input_len()
     }
 
     fn joint_rand_len(&self) -> usize {
@@ -733,6 +745,15 @@ mod tests {
 
         if let Some(ref want) = t.expected_output {
             let got = typ.truncate(input)?;
+
+            if got.len() != typ.output_len() {
+                return Err(PcpError::Test(format!(
+                    "unexpected output length: got {}; want {}",
+                    got.len(),
+                    typ.output_len()
+                )));
+            }
+
             if &got != want {
                 return Err(PcpError::Test(format!(
                     "unexpected output: got {:?}; want {:?}",

--- a/src/vdaf/hits.rs
+++ b/src/vdaf/hits.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! **(NOTE: This module is experimental. Applications should not use it yet.)** This module
-//! implements the `hits` [VDAF]. This is the core component of the privacy-preserving heavy
+//! implements the hits [VDAF]. This is the core component of the privacy-preserving heavy
 //! hitters protocol of [[BBCG+21]].
 //!
 //! TODO Make the input shares stateful so that applications can efficiently evaluate the IDPF over
@@ -26,9 +26,7 @@ use crate::field::{split_vector, FieldElement};
 use crate::fp::log2;
 use crate::prng::Prng;
 use crate::vdaf::suite::{Key, KeyDeriver, KeyStream, Suite};
-use crate::vdaf::{
-    Aggregatable, Aggregator, Client, Collector, PrepareTransition, Share, Vdaf, VdafError,
-};
+use crate::vdaf::{Aggregator, Client, Collector, PrepareTransition, Share, Vdaf, VdafError};
 
 /// An input for an IDPF ([`Idpf`]).
 ///
@@ -422,6 +420,7 @@ impl<I: Idpf<2, 2>> Aggregator for Hits<I> {
         })
     }
 
+    // TODO Fix this clippy warning instead of bypassing it.
     #[allow(clippy::type_complexity)]
     fn prepare_step<M: IntoIterator<Item = Vec<I::Field>>>(
         &self,
@@ -598,24 +597,6 @@ impl<I: Idpf<2, 2>> Collector for Hits<I> {
             agg.insert(*prefix, count);
         }
         Ok(agg)
-    }
-}
-
-impl<F: FieldElement> Aggregatable for Vec<F> {
-    fn merge(&mut self, agg_share: &Vec<F>) -> Result<(), VdafError> {
-        if self.len() != agg_share.len() {
-            return Err(VdafError::Uncategorized(format!(
-                "cannot merge aggregate shares of different lengths (left = {}, right = {})",
-                self.len(),
-                agg_share.len()
-            )));
-        }
-
-        for (x, y) in self.iter_mut().zip(agg_share.iter()) {
-            *x += *y;
-        }
-
-        Ok(())
     }
 }
 

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -1,28 +1,197 @@
 // SPDX-License-Identifier: MPL-2.0
 
 //! **(NOTE: This module is experimental. Applications should not use it yet.)** This modulde
-//! implements the `prio3` [VDAF]. The construction is based on a transform of a Fully Linear Proof
-//! (FLP) system (i.e., a concrete [`Value`](`crate::pcp::Value`) into a zero-knowledge proof
-//! system on distributed data as described in [[BBCG+19], Section 6].
-//!
-//! TODO Align this module with [`crate::vdaf::Vdaf`].
+//! implements the prio3 [VDAF]. The construction is based on a transform of a Fully Linear Proof
+//! (FLP) system (i.e., a concrete [`Type`](crate::pcp::Type) into a zero-knowledge proof system on
+//! distributed data as described in [[BBCG+19], Section 6].
 //!
 //! [BBCG+19]: https://ia.cr/2019/188
 //! [BBCG+21]: https://ia.cr/2021/017
 //! [VDAF]: https://datatracker.ietf.org/doc/draft-patton-cfrg-vdaf/
 
-use crate::field::FieldElement;
+use crate::field::{Field64, Field96, FieldElement};
+use crate::pcp::types::{Count, Histogram, Sum};
 use crate::pcp::Type;
 use crate::prng::Prng;
 use crate::vdaf::suite::{Key, KeyDeriver, KeyStream, Suite};
-use crate::vdaf::{Share, VdafError};
+use crate::vdaf::{Aggregator, Client, Collector, PrepareTransition, Share, Vdaf, VdafError};
 use serde::{Deserialize, Serialize};
+use std::convert::{TryFrom, TryInto};
 use std::iter::IntoIterator;
+use std::marker::PhantomData;
+
+/// The count type. Each measurement is an integer in `[0,2)` and the aggregate is the sum.
+pub type Prio3Count64 = Prio3<Count<Field64>, Prio3Result<u64>>;
+
+impl Prio3Count64 {
+    /// Construct an instance of this VDAF with the given suite and the given number of aggregators.
+    pub fn new(suite: Suite, num_aggregators: u8) -> Result<Self, VdafError> {
+        check_num_aggregators(num_aggregators)?;
+
+        Ok(Prio3 {
+            num_aggregators,
+            suite,
+            typ: Count::<Field64>::new(),
+            phantom: PhantomData,
+        })
+    }
+}
+
+/// The sum type. Each measurement is an integer in `[0,2^bits)` for some `0 < bits < 64` and the
+/// aggregate is the sum.
+pub type Prio3Sum64 = Prio3<Sum<Field96>, Prio3Result<u64>>;
+
+impl Prio3Sum64 {
+    /// Construct an instance of this VDAF with the given suite, number of aggregators and required
+    /// bit length. The bit length must not exceed 64.
+    pub fn new(suite: Suite, num_aggregators: u8, bits: u32) -> Result<Self, VdafError> {
+        check_num_aggregators(num_aggregators)?;
+
+        if bits > 64 {
+            return Err(VdafError::Uncategorized(format!(
+                "bit length ({}) exceeds limit for aggregate type (64)",
+                bits
+            )));
+        }
+
+        Ok(Prio3 {
+            num_aggregators,
+            suite,
+            typ: Sum::<Field96>::new(bits as usize)?,
+            phantom: PhantomData,
+        })
+    }
+}
+
+/// the histogram type. Each measurement is an unsigned, 64-bit integer and the result is a
+/// histogram representation of the measurement.
+pub type Prio3Histogram64 = Prio3<Histogram<Field96>, Prio3ResultVec<u64>>;
+
+impl Prio3Histogram64 {
+    /// Constructs an instance of this VDAF with the given suite, number of aggregators, and
+    /// desired histogram bucket boundaries.
+    pub fn new(suite: Suite, num_aggregators: u8, buckets: &[u64]) -> Result<Self, VdafError> {
+        check_num_aggregators(num_aggregators)?;
+
+        let buckets = buckets.iter().map(|bucket| *bucket as u128).collect();
+
+        Ok(Prio3 {
+            num_aggregators,
+            suite,
+            typ: Histogram::<Field96>::new(buckets)?,
+            phantom: PhantomData,
+        })
+    }
+}
+
+/// Aggregate result for singleton data types.
+#[derive(PartialEq, Eq)]
+pub struct Prio3Result<T: Eq>(T);
+
+impl<F: FieldElement> TryFrom<Vec<F>> for Prio3Result<u64> {
+    type Error = VdafError;
+
+    fn try_from(data: Vec<F>) -> Result<Self, VdafError> {
+        if data.len() != 1 {
+            return Err(VdafError::Uncategorized(format!(
+                "unexpected aggregate length for count type: got {}; want 1",
+                data.len()
+            )));
+        }
+
+        let out: u64 = F::Integer::from(data[0]).try_into().map_err(|err| {
+            VdafError::Uncategorized(format!("result too large for output type: {:?}", err))
+        })?;
+
+        Ok(Prio3Result(out))
+    }
+}
+
+/// Aggregate result for vector data types.
+#[derive(PartialEq, Eq)]
+pub struct Prio3ResultVec<T: Eq>(Vec<T>);
+
+impl<F: FieldElement> TryFrom<Vec<F>> for Prio3ResultVec<u64> {
+    type Error = VdafError;
+
+    fn try_from(data: Vec<F>) -> Result<Self, VdafError> {
+        let mut out = Vec::with_capacity(data.len());
+        for elem in data.into_iter() {
+            out.push(F::Integer::from(elem).try_into().map_err(|err| {
+                VdafError::Uncategorized(format!("result too large for output type: {:?}", err))
+            })?);
+        }
+
+        Ok(Prio3ResultVec(out))
+    }
+}
+
+fn check_num_aggregators(num_aggregators: u8) -> Result<(), VdafError> {
+    if num_aggregators == 0 {
+        return Err(VdafError::Uncategorized(format!(
+            "at least one aggregator is required; got {}",
+            num_aggregators
+        )));
+    } else if num_aggregators > 254 {
+        return Err(VdafError::Uncategorized(format!(
+            "number of aggregators must not exceed 254; got {}",
+            num_aggregators
+        )));
+    }
+
+    Ok(())
+}
+
+/// The base type for prio3.
+pub struct Prio3<T: Type, A> {
+    num_aggregators: u8,
+    suite: Suite,
+    typ: T,
+    phantom: PhantomData<A>,
+}
+
+impl<T: Type, A> Vdaf for Prio3<T, A> {
+    type Measurement = T::Measurement;
+    type AggregateResult = A;
+    type AggregationParam = ();
+    type PublicParam = ();
+    type VerifyParam = Prio3VerifyParam;
+    type InputShare = Prio3InputShare<T::Field>;
+    type OutputShare = Vec<T::Field>;
+    type AggregateShare = Vec<T::Field>;
+
+    fn setup(&self) -> Result<((), Vec<Prio3VerifyParam>), VdafError> {
+        let query_rand_init = Key::generate(self.suite)?;
+        Ok((
+            (),
+            (0..self.num_aggregators)
+                .map(|aggregator_id| Prio3VerifyParam {
+                    query_rand_init: query_rand_init.clone(),
+                    aggregator_id,
+                })
+                .collect(),
+        ))
+    }
+
+    fn num_aggregators(&self) -> usize {
+        self.num_aggregators as usize
+    }
+}
+
+/// The verification parameter used by each aggregator to evaluate the VDAF.
+#[derive(Clone, Debug)]
+pub struct Prio3VerifyParam {
+    /// Key used to derive the query randomness from the nonce.
+    pub query_rand_init: Key,
+
+    /// The identity of the aggregator.
+    pub aggregator_id: u8,
+}
 
 /// The message sent by the client to each aggregator. This includes the client's input share and
 /// the initial message of the input-validation protocol.
 #[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct InputShareMessage<F> {
+pub struct Prio3InputShare<F> {
     /// The input share.
     pub input_share: Share<F>,
 
@@ -37,6 +206,384 @@ pub struct InputShareMessage<F> {
 
     /// The blinding factor, used to derive the aggregator's joint randomness seed share.
     pub blind: Key,
+}
+
+impl<T: Type, A> Client for Prio3<T, A> {
+    fn shard(
+        &self,
+        _public_param: &(),
+        measurement: &T::Measurement,
+    ) -> Result<Vec<Prio3InputShare<T::Field>>, VdafError> {
+        let num_aggregators = self.num_aggregators;
+        let input = self.typ.encode(measurement)?;
+
+        // Generate the input shares and compute the joint randomness.
+        let mut helper_shares = Vec::with_capacity(num_aggregators as usize - 1);
+        let mut leader_input_share = input.clone();
+        let mut joint_rand_seed = Key::uninitialized(self.suite);
+        for aggregator_id in 1..num_aggregators {
+            let mut helper = HelperShare::new(self.suite)?;
+
+            let mut deriver = KeyDeriver::from_key(&helper.blind);
+            deriver.update(&[aggregator_id]);
+            let prng: Prng<T::Field> =
+                Prng::from_key_stream(KeyStream::from_key(&helper.input_share));
+            for (x, y) in leader_input_share
+                .iter_mut()
+                .zip(prng)
+                .take(self.typ.input_len())
+            {
+                *x -= y;
+                deriver.update(&y.into());
+            }
+
+            helper.joint_rand_seed_hint = deriver.finish();
+            for (x, y) in joint_rand_seed
+                .as_mut_slice()
+                .iter_mut()
+                .zip(helper.joint_rand_seed_hint.as_slice().iter())
+            {
+                *x ^= y;
+            }
+
+            helper_shares.push(helper);
+        }
+
+        let leader_blind = Key::generate(self.suite)?;
+
+        let mut deriver = KeyDeriver::from_key(&leader_blind);
+        deriver.update(&[0]); // ID of the leader
+        for x in leader_input_share.iter() {
+            deriver.update(&(*x).into());
+        }
+
+        let mut leader_joint_rand_seed_hint = deriver.finish();
+        for (x, y) in joint_rand_seed
+            .as_mut_slice()
+            .iter_mut()
+            .zip(leader_joint_rand_seed_hint.as_slice().iter())
+        {
+            *x ^= y;
+        }
+
+        // Run the proof-generation algorithm.
+        let prng: Prng<T::Field> = Prng::from_key_stream(KeyStream::from_key(&joint_rand_seed));
+        let joint_rand: Vec<T::Field> = prng.take(self.typ.joint_rand_len()).collect();
+        let prng: Prng<T::Field> = Prng::generate(self.suite)?;
+        let prove_rand: Vec<T::Field> = prng.take(self.typ.prove_rand_len()).collect();
+        let mut leader_proof_share = self.typ.prove(&input, &prove_rand, &joint_rand)?;
+
+        // Generate the proof shares and finalize the joint randomness seed hints.
+        for helper in helper_shares.iter_mut() {
+            let prng: Prng<T::Field> =
+                Prng::from_key_stream(KeyStream::from_key(&helper.proof_share));
+            for (x, y) in leader_proof_share
+                .iter_mut()
+                .zip(prng)
+                .take(self.typ.proof_len())
+            {
+                *x -= y;
+            }
+
+            for (x, y) in helper
+                .joint_rand_seed_hint
+                .as_mut_slice()
+                .iter_mut()
+                .zip(joint_rand_seed.as_slice().iter())
+            {
+                *x ^= y;
+            }
+        }
+
+        for (x, y) in leader_joint_rand_seed_hint
+            .as_mut_slice()
+            .iter_mut()
+            .zip(joint_rand_seed.as_slice().iter())
+        {
+            *x ^= y;
+        }
+
+        // Prep the output messages.
+        let mut out = Vec::with_capacity(num_aggregators as usize);
+        out.push(Prio3InputShare {
+            input_share: Share::Leader(leader_input_share),
+            proof_share: Share::Leader(leader_proof_share),
+            joint_rand_seed_hint: leader_joint_rand_seed_hint,
+            blind: leader_blind,
+        });
+
+        for helper in helper_shares.into_iter() {
+            out.push(Prio3InputShare {
+                input_share: Share::Helper(helper.input_share),
+                proof_share: Share::Helper(helper.proof_share),
+                joint_rand_seed_hint: helper.joint_rand_seed_hint,
+                blind: helper.blind,
+            });
+        }
+
+        Ok(out)
+    }
+}
+
+/// State of each aggregator during the Prepare process.
+#[allow(missing_docs)]
+pub enum Prio3PrepareStep<F> {
+    /// Ready to send the verifier message.
+    Ready {
+        output_share: Vec<F>,
+        joint_rand_seed: Key,
+        verifier_msg: Prio3VerifierMessage<F>,
+    },
+    /// Waiting for the set of verifier messages.
+    Waiting {
+        output_share: Vec<F>,
+        joint_rand_seed: Key,
+    },
+}
+
+impl<T: Type, A> Aggregator for Prio3<T, A> {
+    type PrepareStep = Prio3PrepareStep<T::Field>;
+    type PrepareMessage = Prio3VerifierMessage<T::Field>;
+
+    /// Begins the Prep process with the other aggregators. The result of this process is
+    /// the aggregator's output share.
+    //
+    // TODO(cjpatton) Check that the input share matches `self.suite`.
+    fn prepare_init(
+        &self,
+        verify_param: &Prio3VerifyParam,
+        _agg_param: &(),
+        nonce: &[u8],
+        msg: &Prio3InputShare<T::Field>,
+    ) -> Result<Prio3PrepareStep<T::Field>, VdafError> {
+        let mut deriver = KeyDeriver::from_key(&verify_param.query_rand_init);
+        deriver.update(&[255]);
+        deriver.update(nonce);
+        let query_rand_seed = deriver.finish();
+
+        // Create a reference to the (expanded) input share.
+        let expanded_input_share: Option<Vec<T::Field>> = match msg.input_share {
+            Share::Leader(_) => None,
+            Share::Helper(ref seed) => {
+                let prng = Prng::from_key_stream(KeyStream::from_key(seed));
+                Some(prng.take(self.typ.input_len()).collect())
+            }
+        };
+        let input_share = match msg.input_share {
+            Share::Leader(ref data) => data,
+            Share::Helper(_) => expanded_input_share.as_ref().unwrap(),
+        };
+
+        // Create a reference to the (expanded) proof share.
+        let expanded_proof_share: Option<Vec<T::Field>> = match msg.proof_share {
+            Share::Leader(_) => None,
+            Share::Helper(ref seed) => {
+                let prng = Prng::from_key_stream(KeyStream::from_key(seed));
+                Some(prng.take(self.typ.proof_len()).collect())
+            }
+        };
+        let proof_share = match msg.proof_share {
+            Share::Leader(ref data) => data,
+            Share::Helper(_) => expanded_proof_share.as_ref().unwrap(),
+        };
+
+        // Compute the joint randomness.
+        let mut deriver = KeyDeriver::from_key(&msg.blind);
+        deriver.update(&[verify_param.aggregator_id]);
+        for x in input_share {
+            deriver.update(&(*x).into());
+        }
+        let joint_rand_seed_share = deriver.finish();
+
+        let mut joint_rand_seed = Key::uninitialized(query_rand_seed.suite());
+        for (j, x) in joint_rand_seed.as_mut_slice().iter_mut().enumerate() {
+            *x = msg.joint_rand_seed_hint.as_slice()[j] ^ joint_rand_seed_share.as_slice()[j];
+        }
+
+        let prng: Prng<T::Field> = Prng::from_key_stream(KeyStream::from_key(&joint_rand_seed));
+        let joint_rand: Vec<T::Field> = prng.take(self.typ.joint_rand_len()).collect();
+
+        // Compute the query randomness.
+        let prng: Prng<T::Field> = Prng::from_key_stream(KeyStream::from_key(&query_rand_seed));
+        let query_rand: Vec<T::Field> = prng.take(self.typ.query_rand_len()).collect();
+
+        // Run the query-generation algorithm.
+        let verifier_share = self.typ.query(
+            input_share,
+            proof_share,
+            &query_rand,
+            &joint_rand,
+            self.num_aggregators as usize,
+        )?;
+
+        // Compute the output share.
+        let output_share = self.typ.truncate(input_share)?;
+
+        Ok(Prio3PrepareStep::Ready {
+            output_share,
+            joint_rand_seed,
+            verifier_msg: Prio3VerifierMessage {
+                verifier_share,
+                joint_rand_seed_share,
+            },
+        })
+    }
+
+    // TODO Fix this clippy warning instead of bypassing it.
+    #[allow(clippy::type_complexity)]
+    fn prepare_step<M: IntoIterator<Item = Prio3VerifierMessage<T::Field>>>(
+        &self,
+        state: Prio3PrepareStep<T::Field>,
+        inputs: M,
+    ) -> PrepareTransition<Prio3PrepareStep<T::Field>, Prio3VerifierMessage<T::Field>, Vec<T::Field>>
+    {
+        match state {
+            Prio3PrepareStep::Ready {
+                output_share,
+                joint_rand_seed,
+                verifier_msg,
+            } => {
+                let inputs: Vec<_> = inputs.into_iter().collect();
+                if !inputs.is_empty() {
+                    return PrepareTransition::Fail(VdafError::Uncategorized(format!(
+                        "unexpected message count in ready state: got {}; want 0",
+                        inputs.len()
+                    )));
+                }
+
+                PrepareTransition::Continue(
+                    Prio3PrepareStep::Waiting {
+                        output_share,
+                        joint_rand_seed,
+                    },
+                    verifier_msg,
+                )
+            }
+
+            Prio3PrepareStep::Waiting {
+                output_share,
+                joint_rand_seed,
+            } => {
+                // Combine the verifier messages.
+                //
+                // TODO(cjpatton) Check that there are exactly `self.num_aggregators` messages.
+                // TODO(cjpatton) Check that see matches `self.suite`.
+                let mut verifier = vec![T::Field::zero(); self.typ.verifier_len()];
+                let mut joint_rand_seed_check = Key::uninitialized(self.suite);
+                for msg in inputs.into_iter() {
+                    if msg.verifier_share.len() != verifier.len() {
+                        return PrepareTransition::Fail(VdafError::Uncategorized(format!(
+                            "unexpected verifier share length: got {}; want {}",
+                            msg.verifier_share.len(),
+                            verifier.len(),
+                        )));
+                    }
+
+                    for (x, y) in verifier.iter_mut().zip(msg.verifier_share) {
+                        *x += y;
+                    }
+
+                    for (x, y) in joint_rand_seed_check
+                        .as_mut_slice()
+                        .iter_mut()
+                        .zip(msg.joint_rand_seed_share.as_slice())
+                    {
+                        *x ^= y;
+                    }
+                }
+
+                // Check that the joint randomness was correct.
+                if joint_rand_seed != joint_rand_seed_check {
+                    return PrepareTransition::Fail(VdafError::Uncategorized(
+                        "joint randomness mismatch".to_string(),
+                    ));
+                }
+
+                // Check the proof.
+                let res = match self.typ.decide(&verifier) {
+                    Ok(res) => res,
+                    Err(err) => {
+                        return PrepareTransition::Fail(VdafError::from(err));
+                    }
+                };
+
+                if !res {
+                    return PrepareTransition::Fail(VdafError::Uncategorized(
+                        "proof check failed".to_string(),
+                    ));
+                }
+
+                PrepareTransition::Finish(output_share)
+            }
+        }
+    }
+
+    /// Aggregates a sequence of output shares into an aggregate share.
+    fn aggregate<It: IntoIterator<Item = Vec<T::Field>>>(
+        &self,
+        _agg_param: &(),
+        output_shares: It,
+    ) -> Result<Vec<T::Field>, VdafError> {
+        let mut agg_share = vec![T::Field::zero(); self.typ.output_len()];
+        for output_share in output_shares.into_iter() {
+            if output_share.len() != self.typ.output_len() {
+                return Err(VdafError::Uncategorized(format!(
+                    "unexpected output share length: got {}; want {}",
+                    output_share.len(),
+                    self.typ.output_len()
+                )));
+            }
+
+            for (x, y) in agg_share.iter_mut().zip(output_share) {
+                *x += y;
+            }
+        }
+
+        Ok(agg_share)
+    }
+}
+
+#[derive(Clone, Debug)]
+/// The verification message emitted by each aggregator during the Prepare process.
+pub struct Prio3VerifierMessage<F> {
+    /// The aggregator's share of the FLP verifier message. (See [`Type`](crate::pcp::Type).)
+    pub verifier_share: Vec<F>,
+
+    /// The aggregator's share of the joint randomness, derived from its input share.
+    //
+    // TODO(cjpatton) If `joint_rand_len == 0`, then we don't need to bother with the
+    // joint randomness seed at all and make this optional.
+    pub joint_rand_seed_share: Key,
+}
+
+impl<T, A> Collector for Prio3<T, A>
+where
+    T: Type,
+    A: TryFrom<Vec<T::Field>, Error = VdafError> + Eq,
+{
+    /// Combines aggregate shares into the aggregate result.
+    fn unshard<It: IntoIterator<Item = Vec<T::Field>>>(
+        &self,
+        _agg_param: &(),
+        agg_shares: It,
+    ) -> Result<A, VdafError> {
+        let mut agg = vec![T::Field::zero(); self.typ.output_len()];
+        for agg_share in agg_shares.into_iter() {
+            if agg_share.len() != self.typ.output_len() {
+                return Err(VdafError::Uncategorized(format!(
+                    "unexpected aggregate share length: got {}; want {}",
+                    agg_share.len(),
+                    self.typ.output_len()
+                )));
+            }
+
+            for (x, y) in agg.iter_mut().zip(agg_share) {
+                *x += y;
+            }
+        }
+
+        A::try_from(agg)
+    }
 }
 
 #[derive(Clone)]
@@ -58,377 +605,106 @@ impl HelperShare {
     }
 }
 
-/// The input-distribution algorithm of the VDAF. Run by the client, this generates the sequence of
-/// [`InputShareMessage`] messages to send to the aggregators. Note that this particular VDAF does
-/// not have a public parameter.
-///
-/// # Parameters
-///
-/// * `suite` is the cipher suite used for key derivation.
-/// * `input` is the input to be secret shared.
-/// * `num_shares` is the number of input shares (i.e., aggregators) to generate.
-pub fn prio3_input<V: Type>(
-    suite: Suite,
-    typ: &V,
-    input: &[V::Field],
-    num_shares: u8,
-) -> Result<Vec<InputShareMessage<V::Field>>, VdafError> {
-    check_num_shares("prio3_input", num_shares)?;
-
-    let num_shares = num_shares as usize;
-
-    // Generate the input shares and compute the joint randomness.
-    let mut helper_shares = vec![HelperShare::new(suite)?; num_shares - 1];
-    let mut leader_input_share = input.to_vec();
-    let mut joint_rand_seed = Key::uninitialized(suite);
-    let mut aggregator_id = 1; // ID of the first helper
-    for helper in helper_shares.iter_mut() {
-        let mut deriver = KeyDeriver::from_key(&helper.blind);
-        deriver.update(&[aggregator_id]);
-        let prng: Prng<V::Field> = Prng::from_key_stream(KeyStream::from_key(&helper.input_share));
-        for (x, y) in leader_input_share.iter_mut().zip(prng).take(input.len()) {
-            *x -= y;
-            deriver.update(&y.into());
-        }
-
-        helper.joint_rand_seed_hint = deriver.finish();
-        for (x, y) in joint_rand_seed
-            .as_mut_slice()
-            .iter_mut()
-            .zip(helper.joint_rand_seed_hint.as_slice().iter())
-        {
-            *x ^= y;
-        }
-
-        aggregator_id += 1; // ID of the next helper
-    }
-
-    let leader_blind = Key::generate(suite)?;
-
-    let mut deriver = KeyDeriver::from_key(&leader_blind);
-    deriver.update(&[0]); // ID of the leader
-    for x in leader_input_share.iter() {
-        deriver.update(&(*x).into());
-    }
-
-    let mut leader_joint_rand_seed_hint = deriver.finish();
-    for (x, y) in joint_rand_seed
-        .as_mut_slice()
-        .iter_mut()
-        .zip(leader_joint_rand_seed_hint.as_slice().iter())
-    {
-        *x ^= y;
-    }
-
-    // Run the proof-generation algorithm.
-    let prng: Prng<V::Field> = Prng::from_key_stream(KeyStream::from_key(&joint_rand_seed));
-    let joint_rand: Vec<V::Field> = prng.take(typ.joint_rand_len()).collect();
-    let prng: Prng<V::Field> = Prng::generate(suite)?;
-    let prove_rand: Vec<V::Field> = prng.take(typ.prove_rand_len()).collect();
-    let mut leader_proof_share = typ.prove(input, &prove_rand, &joint_rand)?;
-
-    // Generate the proof shares and finalize the joint randomness seed hints.
-    for helper in helper_shares.iter_mut() {
-        let prng: Prng<V::Field> = Prng::from_key_stream(KeyStream::from_key(&helper.proof_share));
-        for (x, y) in leader_proof_share
-            .iter_mut()
-            .zip(prng)
-            .take(typ.proof_len())
-        {
-            *x -= y;
-        }
-
-        for (x, y) in helper
-            .joint_rand_seed_hint
-            .as_mut_slice()
-            .iter_mut()
-            .zip(joint_rand_seed.as_slice().iter())
-        {
-            *x ^= y;
-        }
-    }
-
-    for (x, y) in leader_joint_rand_seed_hint
-        .as_mut_slice()
-        .iter_mut()
-        .zip(joint_rand_seed.as_slice().iter())
-    {
-        *x ^= y;
-    }
-
-    // Prepare the output messages.
-    let mut out = Vec::with_capacity(num_shares);
-    out.push(InputShareMessage {
-        input_share: Share::Leader(leader_input_share),
-        proof_share: Share::Leader(leader_proof_share),
-        joint_rand_seed_hint: leader_joint_rand_seed_hint,
-        blind: leader_blind,
-    });
-
-    for helper in helper_shares.into_iter() {
-        out.push(InputShareMessage {
-            input_share: Share::Helper(helper.input_share),
-            proof_share: Share::Helper(helper.proof_share),
-            joint_rand_seed_hint: helper.joint_rand_seed_hint,
-            blind: helper.blind,
-        });
-    }
-
-    Ok(out)
-}
-
-/// The verification parameter used by each aggregator to evaluate the VDAF.
-#[derive(Clone, Debug)]
-pub struct VerifyParam<V: Type> {
-    /// Type.
-    pub typ: V,
-
-    /// Key used to derive the query randomness from the nonce.
-    pub query_rand_init: Key,
-
-    /// The identity of the aggregator.
-    pub aggregator_id: u8,
-
-    /// The number of aggregators.
-    pub num_shares: u8,
-}
-
-/// The setup algorithm of the VDAF that generates the verification parameter of each aggregator.
-/// Note that this VDAF does not involve a public parameter.
-#[cfg(test)]
-fn prio3_setup<V: Type>(
-    suite: Suite,
-    typ: &V,
-    num_shares: u8,
-) -> Result<Vec<VerifyParam<V>>, VdafError> {
-    check_num_shares("prio3_setup", num_shares)?;
-
-    let query_rand_init = Key::generate(suite)?;
-    Ok((0..num_shares)
-        .map(|aggregator_id| VerifyParam {
-            typ: typ.clone(),
-            query_rand_init: query_rand_init.clone(),
-            aggregator_id,
-            num_shares,
-        })
-        .collect())
-}
-
-/// The message sent by an aggregator to every other aggregator. This is the final message of the
-/// input-validation protocol.
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct VerifyMessage<F> {
-    /// The aggregator's share of the verifier message.
-    pub verifier_share: Vec<F>,
-
-    /// The aggregator's share of the joint randomness, derived from its input share.
-    //
-    // TODO(cjpatton) If `joint_rand_len == 0`, then we don't need to bother with the
-    // joint randomness seed at all and make this optional.
-    pub joint_rand_seed_share: Key,
-}
-
-/// The state of each aggregator.
-#[derive(Clone, Debug)]
-pub struct VerifyState<V: Type> {
-    typ: V,
-
-    /// The input share.
-    input_share: Vec<V::Field>,
-
-    /// The joint randomness seed indicated by the client. The aggregators check that this
-    /// indication matches the actual joint randomness seed.
-    //
-    // TODO(cjpatton) If `joint_rand_len == 0`, then we don't need to bother with the
-    // joint randomness seed at all and make this optional.
-    joint_rand_seed: Key,
-}
-
-/// The verify-start algorithm of the VDAF. Run by each aggregator, this consumes the
-/// [`InputShareMessage`] message sent from the client and produces the [`VerifyMessage`] message
-/// that will be broadcast to the other aggregators. This VDAF does not involve an aggregation
-/// parameter.
-//
-// TODO(cjpatton) Check for ciphersuite mismatch between `verify_param` and `msg`.
-pub fn prio3_start<V: Type>(
-    verify_param: &VerifyParam<V>,
-    nonce: &[u8],
-    msg: InputShareMessage<V::Field>,
-) -> Result<(VerifyState<V>, VerifyMessage<V::Field>), VdafError> {
-    let typ = verify_param.typ.clone();
-
-    let mut deriver = KeyDeriver::from_key(&verify_param.query_rand_init);
-    deriver.update(&[255]);
-    deriver.update(nonce);
-    let query_rand_seed = deriver.finish();
-
-    let input_share = msg.input_share.into_vec(typ.input_len())?;
-    let proof_share = msg.proof_share.into_vec(typ.proof_len())?;
-
-    // Compute the joint randomness.
-    let mut deriver = KeyDeriver::from_key(&msg.blind);
-    deriver.update(&[verify_param.aggregator_id]);
-    for x in input_share.as_slice() {
-        deriver.update(&(*x).into());
-    }
-    let joint_rand_seed_share = deriver.finish();
-
-    let mut joint_rand_seed = Key::uninitialized(query_rand_seed.suite());
-    for (j, x) in joint_rand_seed.as_mut_slice().iter_mut().enumerate() {
-        *x = msg.joint_rand_seed_hint.as_slice()[j] ^ joint_rand_seed_share.as_slice()[j];
-    }
-
-    let prng: Prng<V::Field> = Prng::from_key_stream(KeyStream::from_key(&joint_rand_seed));
-    let joint_rand: Vec<V::Field> = prng.take(typ.joint_rand_len()).collect();
-
-    // Compute the query randomness.
-    let prng: Prng<V::Field> = Prng::from_key_stream(KeyStream::from_key(&query_rand_seed));
-    let query_rand: Vec<V::Field> = prng.take(typ.query_rand_len()).collect();
-
-    // Run the query-generation algorithm.
-    let verifier_share = typ.query(
-        &input_share,
-        &proof_share,
-        &query_rand,
-        &joint_rand,
-        verify_param.num_shares as usize,
-    )?;
-
-    // Prepare the output state and message.
-    let state = VerifyState {
-        typ,
-        input_share,
-        joint_rand_seed,
-    };
-
-    let out = VerifyMessage {
-        verifier_share,
-        joint_rand_seed_share,
-    };
-
-    Ok((state, out))
-}
-
-/// The verify-finish algorithm of the VDAF. Run by each aggregator, this consumes the
-/// [`VerifyMessage`] messages broadcast by all of the aggregators and produces the aggregator's
-/// input share.
-//
-// TODO(cjpatton) Check for ciphersuite mismatch between `state` and `msgs` and among `msgs`.
-pub fn prio3_finish<M, V>(mut state: VerifyState<V>, msgs: M) -> Result<Vec<V::Field>, VdafError>
-where
-    V: Type,
-    M: IntoIterator<Item = VerifyMessage<V::Field>>,
-{
-    let mut msgs = msgs.into_iter().peekable();
-
-    let verifier_length = match msgs.peek() {
-        Some(message) => message.verifier_share.as_slice().len(),
-        None => {
-            return Err(VdafError::Uncategorized(
-                "prio3_finish(): expected at least one inbound messages; got none".to_string(),
-            ));
-        }
-    };
-
-    // Combine the verifier messages.
-    let mut verifier = vec![V::Field::zero(); verifier_length];
-    for msg in msgs {
-        if msg.verifier_share.len() != verifier.len() {
-            return Err(VdafError::Uncategorized(format!(
-                "prio3_finish(): expected verifier share of length {}; got {}",
-                verifier.len(),
-                msg.verifier_share.len(),
-            )));
-        }
-
-        for (x, y) in verifier.iter_mut().zip(msg.verifier_share) {
-            *x += y;
-        }
-
-        for (x, y) in state
-            .joint_rand_seed
-            .as_mut_slice()
-            .iter_mut()
-            .zip(msg.joint_rand_seed_share.as_slice())
-        {
-            *x ^= y;
-        }
-    }
-
-    // Check that the joint randomness was correct.
-    if state.joint_rand_seed != Key::uninitialized(state.joint_rand_seed.suite()) {
-        return Err(VdafError::Uncategorized(
-            "joint randomness mismatch".to_string(),
-        ));
-    }
-
-    // Check the proof.
-    let result = state.typ.decide(&verifier)?;
-    if !result {
-        return Err(VdafError::Uncategorized("proof check failed".to_string()));
-    }
-
-    Ok(state.input_share)
-}
-
-fn check_num_shares(func_name: &str, num_shares: u8) -> Result<(), VdafError> {
-    if num_shares == 0 {
-        return Err(VdafError::Uncategorized(format!(
-            "{}(): at least one share is required; got {}",
-            func_name, num_shares
-        )));
-    } else if num_shares > 254 {
-        return Err(VdafError::Uncategorized(format!(
-            "{}(): share count must not exceed 254; got {}",
-            func_name, num_shares
-        )));
-    }
-    Ok(())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    use crate::field::Field64;
-    use crate::pcp::types::Count;
+    #[test]
+    fn test_prio3_count64() {
+        let prio3 = Prio3Count64::new(Suite::Blake3, 23).unwrap();
+        let (_, verify_params) = prio3.setup().unwrap();
+        let nonce = b"This is a good nonce.";
+        let input_shares = prio3.shard(&(), &1).unwrap();
+        eval_vdaf(
+            &prio3,
+            &input_shares,
+            &verify_params,
+            nonce,
+            Some(Prio3Result(1)),
+        )
+        .unwrap();
+
+        // TODO(cjpatton) Add failure test cases.
+    }
 
     #[test]
-    fn test_prio3() {
-        let suite = Suite::Blake3;
-        const NUM_SHARES: usize = 23;
+    fn test_prio3_input_share() {
+        let prio3 = Prio3Count64::new(Suite::Blake3, 5).unwrap();
+        let input_shares = prio3.shard(&(), &1).unwrap();
 
-        let count = Count::new();
-        let input: Vec<Field64> = count.encode(&1).unwrap();
-        let nonce = b"This is a good nonce.";
+        // Check that seed shares are distinct.
+        for (i, x) in input_shares.iter().enumerate() {
+            for (j, y) in input_shares.iter().enumerate() {
+                if i != j {
+                    match (&x.input_share, &y.input_share) {
+                        (Share::Helper(left), Share::Helper(right)) => {
+                            assert_ne!(left, right);
+                        }
+                        _ => (),
+                    };
 
-        // Client runs the input and proof distribution algorithms.
-        let input_shares = prio3_input(suite, &count, &input, NUM_SHARES as u8).unwrap();
+                    match (&x.proof_share, &y.proof_share) {
+                        (Share::Helper(left), Share::Helper(right)) => {
+                            assert_ne!(left, right);
+                        }
+                        _ => (),
+                    };
 
-        // Aggregators agree on seed used to generate per-report query randomness.
-        let verify_params = prio3_setup(suite, &count, NUM_SHARES as u8).unwrap();
-
-        // Aggregators receive their proof shares and broadcast their verifier messages.
-        let (states, verifiers): (
-            Vec<VerifyState<Count<Field64>>>,
-            Vec<VerifyMessage<Field64>>,
-        ) = verify_params
-            .iter()
-            .zip(input_shares.into_iter())
-            .map(|(verify_param, input_share)| {
-                prio3_start(verify_param, &nonce[..], input_share).unwrap()
-            })
-            .unzip();
-
-        // Aggregators decide whether the input is valid based on the verifier messages.
-        let mut output = vec![Field64::zero(); input.as_slice().len()];
-        for state in states {
-            let output_share = prio3_finish(state, verifiers.clone()).unwrap();
-            for (x, y) in output.iter_mut().zip(output_share.as_slice()) {
-                *x += *y;
+                    assert_ne!(x.joint_rand_seed_hint, y.joint_rand_seed_hint);
+                    assert_ne!(x.blind, y.blind);
+                }
             }
         }
+    }
 
-        assert_eq!(input.as_slice(), output.as_slice());
+    // Execute the VDAF end-to-end on a single user measurement.
+    fn eval_vdaf<T, A>(
+        prio3: &Prio3<T, A>,
+        input_shares: &[Prio3InputShare<T::Field>],
+        verify_params: &[Prio3VerifyParam],
+        nonce: &[u8],
+        expected_agg: Option<A>,
+    ) -> Result<(), VdafError>
+    where
+        T: Type,
+        A: TryFrom<Vec<T::Field>, Error = VdafError> + Eq,
+    {
+        let mut state0: Vec<Prio3PrepareStep<T::Field>> =
+            Vec::with_capacity(prio3.num_aggregators());
+        for (verify_param, input_share) in verify_params.iter().zip(input_shares.iter()) {
+            let state = prio3.prepare_init(verify_param, &(), nonce, input_share)?;
+            state0.push(state);
+        }
+
+        let mut round1: Vec<Prio3VerifierMessage<T::Field>> =
+            Vec::with_capacity(prio3.num_aggregators());
+        let mut state1: Vec<Prio3PrepareStep<T::Field>> =
+            Vec::with_capacity(prio3.num_aggregators());
+        for state in state0.into_iter() {
+            let (state, msg) = prio3.prepare_start(state)?;
+            state1.push(state);
+            round1.push(msg);
+        }
+
+        let mut agg_shares: Vec<Vec<T::Field>> = Vec::with_capacity(prio3.num_aggregators());
+        for state in state1.into_iter() {
+            let output_share = prio3.prepare_finish(state, round1.clone())?;
+            agg_shares.push(prio3.aggregate(&(), [output_share])?);
+        }
+
+        if let Some(want) = expected_agg {
+            let got = prio3.unshard(&(), agg_shares)?;
+            if got != want {
+                return Err(VdafError::Uncategorized(
+                    "unexpected output for test case".to_string(),
+                ));
+            }
+        } else {
+            return Err(VdafError::Uncategorized(
+                "test case expected no output, got some".to_string(),
+            ));
+        }
+
+        Ok(())
     }
 }


### PR DESCRIPTION
While at it, this adds an `output_len` to `Type` for getting the length
of the truncated output. This is used for aggregation.
