### PR TITLE
Add benchmarks for prio3 client

### DIFF
--- a/src/vdaf/suite.rs
+++ b/src/vdaf/suite.rs
@@ -81,6 +81,13 @@ impl Key {
         }
     }
 
+    /// Return the length in bytes of the key.
+    pub fn size(&self) -> usize {
+        match self {
+            Self::Aes128CtrHmacSha256(_) | Self::Blake3(_) => 32,
+        }
+    }
+
     /// Returns an uninitialized (i.e., zero-valued) key. The caller is expected to initialize the
     /// key with a (pseudo)random input.
     pub(crate) fn uninitialized(suite: Suite) -> Self {


### PR DESCRIPTION
I'm preparing my deck for the presentation of draft-patton-cfrg-vdaf-00 at CFRG next week, and I wanted to get some benchmarks to report.

| type | shard time | total input share size (2 aggregators) |
|-------|-------------|-------------|
| Prio3Count64 | 8 microseconds (us) | 208 bytes |
| Prio3Histogram64 (10 buckets) | 15 us | 432 bytes |
| Prio3Sum64 (32 bits) | 35 us | 960 bytes |