### PR TITLE
pcp: Properly validate inputs of `Sum::encode()`

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -22,7 +22,7 @@ use std::{
     hash::{Hash, Hasher},
     io::{Cursor, Read},
     marker::PhantomData,
-    ops::{Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Neg, Shr, Sub, SubAssign},
+    ops::{Add, AddAssign, BitAnd, Div, DivAssign, Mul, MulAssign, Neg, Shl, Shr, Sub, SubAssign},
 };
 
 /// Possible errors from finite field operations.
@@ -96,6 +96,7 @@ pub trait FieldElement:
         + Ord
         + BitAnd<Output = <Self as FieldElement>::Integer>
         + Div<Output = <Self as FieldElement>::Integer>
+        + Shl<Output = <Self as FieldElement>::Integer>
         + Shr<Output = <Self as FieldElement>::Integer>
         + Sub<Output = <Self as FieldElement>::Integer>
         + From<Self>


### PR DESCRIPTION
If `self.bits == 64` then this method will panic. The behavior that we
want is that encoding should succeed if `2^self.bits` can be encoded as
a field element. This change has performs this check in the constructor.
Also, the constructor now computes the maximum representable integer
than can be represented so that the encoding method can check this
properly.