### PR TITLE
prio3: Add a type for a vector of counters

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,10 +17,14 @@ jobs:
     - uses: actions/checkout@v2
     - name: Lint
       run: cargo fmt --message-format human -- --check
-    - name: Build
+    - name: Build (default features)
       run: cargo build --verbose --workspace
-    - name: Run tests
+    - name: Build (all features)
+      run: cargo build --verbose --workspace --all-features
+    - name: Run tests (default features)
       run: cargo test --verbose
+    - name: Run tests (all features)
+      run: cargo test --verbose --all-features
     - name: Build benchmarks
       run: cargo bench --no-run
     - name: clippy

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -672,6 +672,7 @@ dependencies = [
  "num-bigint",
  "prio",
  "rand",
+ "rayon",
  "ring",
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,9 @@ thiserror = "1.0"
 rand = { version = "0.8", optional = true }
 serde_json = { version = "1.0", optional = true }
 
+# dependencies required if feature "multithreaded" is enabled
+rayon = { version = "1.5.1", optional = true }
+
 [dev-dependencies]
 assert_matches = "1.5.0"
 criterion = "0.3"
@@ -35,6 +38,7 @@ prio = { path = ".", features = ["test-vector"] }
 
 [features]
 test-vector = ["rand", "serde_json"]
+multithreaded = ["rayon"]
 
 [workspace]
 members = ["binaries"]
@@ -46,3 +50,7 @@ harness = false
 
 [[example]]
 name = "sum"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MPL-2.0
 
 #![warn(missing_docs)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 //! Libprio-rs
 //!

--- a/src/pcp.rs
+++ b/src/pcp.rs
@@ -486,7 +486,7 @@ pub trait Type: Sized + Eq + Clone + Debug {
 }
 
 /// A gadget, a non-affine arithmetic circuit that is called when evaluating a validity circuit.
-pub trait Gadget<F: FieldElement> {
+pub trait Gadget<F: FieldElement>: Debug {
     /// Evaluates the gadget on input `inp` and returns the output.
     fn call(&mut self, inp: &[F]) -> Result<F, PcpError>;
 
@@ -510,6 +510,7 @@ pub trait Gadget<F: FieldElement> {
 
 // A "shim" gadget used during proof generation to record the input wires each time a gadget is
 // evaluated.
+#[derive(Debug)]
 struct ProveShimGadget<F: FieldElement> {
     inner: Box<dyn Gadget<F>>,
 
@@ -571,6 +572,7 @@ impl<F: FieldElement> Gadget<F> for ProveShimGadget<F> {
 
 // A "shim" gadget used during proof verification to record the points at which the intermediate
 // proof polynomials are evaluated.
+#[derive(Debug)]
 struct QueryShimGadget<F: FieldElement> {
     inner: Box<dyn Gadget<F>>,
 
@@ -765,11 +767,11 @@ mod tests {
         fn proof_len(&self) -> usize {
             // First chunk
             let mul = 2 /* gadget arity */ + 2 /* gadget degree */ * (
-                (1 + 2 /* gadget calls */ as usize).next_power_of_two() - 1) + 1;
+                (1 + 2_usize /* gadget calls */).next_power_of_two() - 1) + 1;
 
             // Second chunk
             let poly = 1 /* gadget arity */ + 3 /* gadget degree */ * (
-                (1 + 1 /* gadget calls */ as usize).next_power_of_two() - 1) + 1;
+                (1 + 1_usize /* gadget calls */).next_power_of_two() - 1) + 1;
 
             mul + poly
         }

--- a/src/pcp/gadgets.rs
+++ b/src/pcp/gadgets.rs
@@ -7,14 +7,20 @@ use crate::field::FieldElement;
 use crate::pcp::{Gadget, PcpError};
 use crate::polynomial::{poly_deg, poly_eval, poly_mul};
 
+#[cfg(feature = "multithreaded")]
+use rayon::prelude::*;
+
 use std::any::Any;
 use std::convert::TryFrom;
+use std::fmt::Debug;
+use std::marker::PhantomData;
 
 /// For input polynomials larger than or equal to this threshold, gadgets will use FFT for
 /// polynomial multiplication. Otherwise, the gadget uses direct multiplication.
 const FFT_THRESHOLD: usize = 60;
 
 /// An arity-2 gadget that multiples its inputs.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Mul<F: FieldElement> {
     /// Size of buffer for FFT operations.
     n: usize,
@@ -104,6 +110,7 @@ impl<F: FieldElement> Gadget<F> for Mul<F> {
 /// An arity-1 gadget that evaluates its input on some polynomial.
 //
 // TODO Make `poly` an array of length determined by a const generic.
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct PolyEval<F: FieldElement> {
     poly: Vec<F>,
     /// Size of buffer for FFT operations.
@@ -214,7 +221,266 @@ impl<F: FieldElement> Gadget<F> for PolyEval<F> {
     }
 }
 
-// Check that the input parameters of g.call() are wll-formed.
+/// An arity-2 gadget that returns `poly(in[0]) * in[1]` for some polynomial `poly`.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BlindPolyEval<F: FieldElement> {
+    poly: Vec<F>,
+    /// Size of buffer for the outer FFT multiplication.
+    n: usize,
+    /// Inverse of `n` in `F`.
+    n_inv: F,
+    /// The number of times this gadget will be called.
+    num_calls: usize,
+}
+
+impl<F: FieldElement> BlindPolyEval<F> {
+    /// Returns a `BlindPolyEval` gadget for polynomial `poly`.
+    pub fn new(poly: Vec<F>, num_calls: usize) -> Self {
+        let n = ((poly_deg(&poly) + 1) * (1 + num_calls).next_power_of_two()).next_power_of_two();
+        let n_inv = F::from(F::Integer::try_from(n).unwrap()).inv();
+        Self {
+            poly,
+            n,
+            n_inv,
+            num_calls,
+        }
+    }
+
+    fn call_poly_direct(&mut self, outp: &mut [F], inp: &[Vec<F>]) -> Result<(), PcpError> {
+        let x = &inp[0];
+        let y = &inp[1];
+
+        let mut z = y.to_vec();
+        for i in 0..self.poly.len() {
+            for j in 0..z.len() {
+                outp[j] += self.poly[i] * z[j];
+            }
+
+            if i < self.poly.len() - 1 {
+                z = poly_mul(&z, x);
+            }
+        }
+        Ok(())
+    }
+
+    fn call_poly_fft(&mut self, outp: &mut [F], inp: &[Vec<F>]) -> Result<(), PcpError> {
+        let n = self.n;
+        let x = &inp[0];
+        let y = &inp[1];
+
+        let mut x_vals = vec![F::zero(); n];
+        discrete_fourier_transform(&mut x_vals, x, n)?;
+
+        let mut z_vals = vec![F::zero(); n];
+        discrete_fourier_transform(&mut z_vals, y, n)?;
+
+        let mut z = vec![F::zero(); n];
+        let mut z_len = y.len();
+        z[..y.len()].clone_from_slice(y);
+
+        for i in 0..self.poly.len() {
+            for j in 0..z_len {
+                outp[j] += self.poly[i] * z[j];
+            }
+
+            if i < self.poly.len() - 1 {
+                for j in 0..n {
+                    z_vals[j] *= x_vals[j];
+                }
+
+                discrete_fourier_transform(&mut z, &z_vals, n)?;
+                discrete_fourier_transform_inv_finish(&mut z, n, self.n_inv);
+                z_len += x.len();
+            }
+        }
+        Ok(())
+    }
+}
+
+impl<F: FieldElement> Gadget<F> for BlindPolyEval<F> {
+    fn call(&mut self, inp: &[F]) -> Result<F, PcpError> {
+        gadget_call_check(self, inp.len())?;
+        Ok(inp[1] * poly_eval(&self.poly, inp[0]))
+    }
+
+    fn call_poly(&mut self, outp: &mut [F], inp: &[Vec<F>]) -> Result<(), PcpError> {
+        gadget_call_poly_check(self, outp, inp)?;
+
+        for x in outp.iter_mut() {
+            *x = F::zero();
+        }
+
+        if inp[0].len() >= FFT_THRESHOLD {
+            self.call_poly_fft(outp, inp)
+        } else {
+            self.call_poly_direct(outp, inp)
+        }
+    }
+
+    fn arity(&self) -> usize {
+        2
+    }
+
+    fn degree(&self) -> usize {
+        poly_deg(&self.poly) + 1
+    }
+
+    fn calls(&self) -> usize {
+        self.num_calls
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// Marker trait for abstracting over [`ParallelSum`] and [`ParallelSumMultithreaded`]
+pub trait ParallelSumGadget<F: FieldElement, G>: Gadget<F> + Debug {
+    /// Wraps `inner` into a sum gadget with `chunks` chunks
+    fn new(inner: G, chunks: usize) -> Self;
+}
+
+/// A wrapper gadget that applies the inner gadget to chunks of input and returns the sum of the
+/// outputs. The arity is equal to the arity of the inner gadget times the number of chunks.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ParallelSum<F: FieldElement, G: Gadget<F>> {
+    inner: G,
+    chunks: usize,
+    phantom: PhantomData<F>,
+}
+
+impl<F: FieldElement, G: 'static + Gadget<F>> ParallelSumGadget<F, G> for ParallelSum<F, G> {
+    fn new(inner: G, chunks: usize) -> Self {
+        Self {
+            inner,
+            chunks,
+            phantom: PhantomData,
+        }
+    }
+}
+
+impl<F: FieldElement, G: 'static + Gadget<F>> Gadget<F> for ParallelSum<F, G> {
+    fn call(&mut self, inp: &[F]) -> Result<F, PcpError> {
+        gadget_call_check(self, inp.len())?;
+        let mut outp = F::zero();
+        for chunk in inp.chunks(self.inner.arity()) {
+            outp += self.inner.call(chunk)?;
+        }
+        Ok(outp)
+    }
+
+    fn call_poly(&mut self, outp: &mut [F], inp: &[Vec<F>]) -> Result<(), PcpError> {
+        gadget_call_poly_check(self, outp, inp)?;
+
+        for x in outp.iter_mut() {
+            *x = F::zero();
+        }
+
+        let mut partial_outp = vec![F::zero(); outp.len()];
+
+        for chunk in inp.chunks(self.inner.arity()) {
+            self.inner.call_poly(&mut partial_outp, chunk)?;
+            for i in 0..outp.len() {
+                outp[i] += partial_outp[i]
+            }
+        }
+
+        Ok(())
+    }
+
+    fn arity(&self) -> usize {
+        self.chunks * self.inner.arity()
+    }
+
+    fn degree(&self) -> usize {
+        self.inner.degree()
+    }
+
+    fn calls(&self) -> usize {
+        self.inner.calls()
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+/// A wrapper gadget that applies the inner gadget to chunks of input and returns the sum of the
+/// outputs. The arity is equal to the arity of the inner gadget times the number of chunks. The sum
+/// evaluation is multithreaded.
+#[cfg(feature = "multithreaded")]
+#[cfg_attr(docsrs, doc(cfg(feature = "multithreaded")))]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ParallelSumMultithreaded<F: FieldElement, G: Gadget<F>> {
+    serial_sum: ParallelSum<F, G>,
+}
+
+#[cfg(feature = "multithreaded")]
+impl<F, G> ParallelSumGadget<F, G> for ParallelSumMultithreaded<F, G>
+where
+    F: FieldElement + Sync + Send,
+    G: 'static + Gadget<F> + Clone + Sync,
+{
+    fn new(inner: G, chunks: usize) -> Self {
+        Self {
+            serial_sum: ParallelSum::new(inner, chunks),
+        }
+    }
+}
+
+#[cfg(feature = "multithreaded")]
+impl<F, G> Gadget<F> for ParallelSumMultithreaded<F, G>
+where
+    F: FieldElement + Sync + Send,
+    G: 'static + Gadget<F> + Clone + Sync,
+{
+    fn call(&mut self, inp: &[F]) -> Result<F, PcpError> {
+        self.serial_sum.call(inp)
+    }
+
+    fn call_poly(&mut self, outp: &mut [F], inp: &[Vec<F>]) -> Result<(), PcpError> {
+        gadget_call_poly_check(self, outp, inp)?;
+
+        let res = inp
+            .par_chunks(self.serial_sum.inner.arity())
+            .map(|chunk| {
+                let mut inner = self.serial_sum.inner.clone();
+                let mut partial_outp = vec![F::zero(); outp.len()];
+                inner.call_poly(&mut partial_outp, chunk).unwrap();
+                partial_outp
+            })
+            .reduce(
+                || vec![F::zero(); outp.len()],
+                |mut x, y| {
+                    for i in 0..x.len() {
+                        x[i] += y[i];
+                    }
+                    x
+                },
+            );
+
+        outp.clone_from_slice(&res[..outp.len()]);
+        Ok(())
+    }
+
+    fn arity(&self) -> usize {
+        self.serial_sum.arity()
+    }
+
+    fn degree(&self) -> usize {
+        self.serial_sum.degree()
+    }
+
+    fn calls(&self) -> usize {
+        self.serial_sum.calls()
+    }
+
+    fn as_any(&mut self) -> &mut dyn Any {
+        self
+    }
+}
+
+// Check that the input parameters of g.call() are well-formed.
 fn gadget_call_check<F: FieldElement, G: Gadget<F>>(
     gadget: &G,
     in_len: usize,
@@ -296,6 +562,73 @@ mod tests {
         let num_calls = FFT_THRESHOLD;
         let mut g: PolyEval<TestField> = PolyEval::new(poly, num_calls);
         gadget_test(&mut g, num_calls);
+    }
+
+    #[test]
+    fn test_blind_poly_eval() {
+        let poly: Vec<TestField> = Prng::generate(Suite::Blake3).unwrap().take(10).collect();
+
+        let num_calls = FFT_THRESHOLD / 2;
+        let mut g: BlindPolyEval<TestField> = BlindPolyEval::new(poly.clone(), num_calls);
+        gadget_test(&mut g, num_calls);
+
+        let num_calls = FFT_THRESHOLD;
+        let mut g: BlindPolyEval<TestField> = BlindPolyEval::new(poly, num_calls);
+        gadget_test(&mut g, num_calls);
+    }
+
+    #[test]
+    fn test_parallel_sum() {
+        let poly: Vec<TestField> = Prng::generate(Suite::Blake3).unwrap().take(10).collect();
+        let num_calls = 10;
+        let chunks = 23;
+
+        let mut g = ParallelSum::new(BlindPolyEval::new(poly, num_calls), chunks);
+        gadget_test(&mut g, num_calls);
+    }
+
+    #[test]
+    #[cfg(feature = "multithreaded")]
+    fn test_parallel_sum_multithreaded() {
+        let poly: Vec<TestField> = Prng::generate(Suite::Blake3).unwrap().take(10).collect();
+        let num_calls = 10;
+        let chunks = 23;
+
+        let mut g =
+            ParallelSumMultithreaded::new(BlindPolyEval::new(poly.clone(), num_calls), chunks);
+        gadget_test(&mut g, num_calls);
+
+        // Test that the multithreaded version has the same output as the normal version.
+        let mut g_serial = ParallelSum::new(BlindPolyEval::new(poly, num_calls), chunks);
+        assert_eq!(g.arity(), g_serial.arity());
+        assert_eq!(g.degree(), g_serial.degree());
+        assert_eq!(g.calls(), g_serial.calls());
+
+        let arity = g.arity();
+        let degree = g.degree();
+
+        // Test that both gadgets evaluate to the same value when run on scalar inputs.
+        let inp: Vec<TestField> = Prng::generate(Suite::Blake3).unwrap().take(arity).collect();
+        let result = g.call(&inp).unwrap();
+        let result_serial = g_serial.call(&inp).unwrap();
+        assert_eq!(result, result_serial);
+
+        // Test that both gadgets evaluate to the same value when run on polynomial inputs.
+        let mut poly_outp = vec![TestField::zero(); (degree * (1 + num_calls)).next_power_of_two()];
+        let mut poly_outp_serial =
+            vec![TestField::zero(); (degree * (1 + num_calls)).next_power_of_two()];
+        let mut poly_inp = vec![vec![TestField::zero(); 1 + num_calls]; arity];
+        let mut prng: Prng<TestField> = Prng::generate(Suite::Blake3).unwrap();
+        for i in 0..arity {
+            for j in 0..num_calls {
+                poly_inp[i][j] = prng.get();
+            }
+        }
+        g.call_poly(&mut poly_outp, &poly_inp).unwrap();
+        g_serial
+            .call_poly(&mut poly_outp_serial, &poly_inp)
+            .unwrap();
+        assert_eq!(poly_outp, poly_outp_serial);
     }
 
     // Test that calling g.call_poly() and evaluating the output at a given point is equivalent


### PR DESCRIPTION
Adds the `Prio3CountVec64` type, which has comparable functionality to "Prio v2". Its main advantage is that the proof size is significantly smaller. The cost of this reduction in proof size that proof generation is somewhat more expensive. (See benchmarks in #37 for some rough numbers.)

While at it, this fixes the input-share size computation in the benchmarks.