### PR TITLE
prio3: Store (compressed) input share instead of output share

### DIFF
--- a/src/pcp.rs
+++ b/src/pcp.rs
@@ -178,7 +178,7 @@ pub trait Type: Sized + Eq + Clone + Debug {
 
     /// Constructs an aggregatable output from an encoded input. Calling this method is only safe
     /// once `input` has been validated.
-    fn truncate(&self, input: &[Self::Field]) -> Result<Vec<Self::Field>, PcpError>;
+    fn truncate(&self, input: Vec<Self::Field>) -> Result<Vec<Self::Field>, PcpError>;
 
     /// The length in field elements of the encoded input returned by [`Self::encode`].
     fn input_len(&self) -> usize;
@@ -814,8 +814,8 @@ mod tests {
             ])
         }
 
-        fn truncate(&self, input: &[F]) -> Result<Vec<F>, PcpError> {
-            Ok(input.to_vec())
+        fn truncate(&self, input: Vec<F>) -> Result<Vec<F>, PcpError> {
+            Ok(input)
         }
     }
 }

--- a/src/pcp/types.rs
+++ b/src/pcp/types.rs
@@ -67,9 +67,9 @@ impl<F: FieldElement> Type for Count<F> {
         Ok(v)
     }
 
-    fn truncate(&self, input: &[F]) -> Result<Vec<F>, PcpError> {
-        truncate_call_check(self, input)?;
-        Ok(input.to_vec())
+    fn truncate(&self, input: Vec<F>) -> Result<Vec<F>, PcpError> {
+        truncate_call_check(self, &input)?;
+        Ok(input)
     }
 
     fn input_len(&self) -> usize {
@@ -192,8 +192,8 @@ impl<F: FieldElement> Type for Sum<F> {
         Ok(range_check)
     }
 
-    fn truncate(&self, input: &[F]) -> Result<Vec<F>, PcpError> {
-        truncate_call_check(self, input)?;
+    fn truncate(&self, input: Vec<F>) -> Result<Vec<F>, PcpError> {
+        truncate_call_check(self, &input)?;
 
         let mut decoded = F::zero();
         for (l, bit) in input.iter().enumerate() {
@@ -317,9 +317,9 @@ impl<F: FieldElement> Type for Histogram<F> {
         Ok(out)
     }
 
-    fn truncate(&self, input: &[F]) -> Result<Vec<F>, PcpError> {
-        truncate_call_check(self, input)?;
-        Ok(input.to_vec())
+    fn truncate(&self, input: Vec<F>) -> Result<Vec<F>, PcpError> {
+        truncate_call_check(self, &input)?;
+        Ok(input)
     }
 
     fn input_len(&self) -> usize {
@@ -754,7 +754,7 @@ mod tests {
         }
 
         if let Some(ref want) = t.expected_output {
-            let got = typ.truncate(input)?;
+            let got = typ.truncate(input.to_vec())?;
 
             if got.len() != typ.output_len() {
                 return Err(PcpError::Test(format!(


### PR DESCRIPTION
The Aggregator must store its output share for the duration of the
validation process. In the PPM protocol, the Helper may end up
serializing this state and sending it encrypted in its HTTP response. In
general, it is more communication efficient to send the seed used to
generate the input share rather than the output share.

This changes the internal structure of `Prio3PrepareStep` so that the
(compressed) input share is stored instead of the output share. While at
it, this changes the interface of `Type::truncate` so that it consumes
its input. This avoids a copy in prio3.