### PR TITLE
Implement generic 128-bit prime field arithmetic.

### DIFF
--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -5,7 +5,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use prio::benchmarked::*;
 use prio::client::Client as Prio2Client;
 use prio::encrypt::PublicKey;
-use prio::field::{random_vector, Field126 as F, FieldElement};
+use prio::field::{random_vector, Field128 as F, FieldElement};
 use prio::pcp::gadgets::Mul;
 use prio::server::{generate_verification_message, ValidationMemory};
 #[cfg(feature = "multithreaded")]

--- a/src/fft.rs
+++ b/src/fft.rs
@@ -116,7 +116,7 @@ fn bitrev(d: usize, x: usize) -> usize {
 mod tests {
     use super::*;
     use crate::field::{
-        random_vector, split_vector, Field126, Field32, Field64, Field96, FieldPriov2,
+        random_vector, split_vector, Field128, Field32, Field64, Field96, FieldPriov2,
     };
     use crate::polynomial::{poly_fft, PolyAuxMemory};
 
@@ -157,8 +157,8 @@ mod tests {
     }
 
     #[test]
-    fn test_field126() {
-        discrete_fourier_transform_then_inv_test::<Field126>().expect("unexpected error");
+    fn test_field128() {
+        discrete_fourier_transform_then_inv_test::<Field128>().expect("unexpected error");
     }
 
     #[test]

--- a/src/field.rs
+++ b/src/field.rs
@@ -7,7 +7,7 @@
 //! subgroup of order `2^n` for some `n`.
 
 use crate::{
-    fp::{FP126, FP32, FP64, FP96},
+    fp::{FP128, FP32, FP64, FP96},
     prng::{Prng, PrngError},
     vdaf::suite::Suite,
 };
@@ -567,10 +567,10 @@ make_field!(
 );
 
 make_field!(
-    /// `GF(85070591730234613043491808580380655617)`, a 126-bit field.
-    Field126,
+    /// `GF(340282366920938462946865773367900766209)`, a 128-bit field.
+    Field128,
     u128,
-    FP126,
+    FP128,
     16,
     ByteOrder::BigEndian,
 );
@@ -775,7 +775,7 @@ mod tests {
     }
 
     #[test]
-    fn test_field126() {
-        field_element_test::<Field126>();
+    fn test_field128() {
+        field_element_test::<Field128>();
     }
 }

--- a/src/pcp.rs
+++ b/src/pcp.rs
@@ -665,7 +665,7 @@ impl<F: FieldElement> Gadget<F> for QueryShimGadget<F> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::field::{random_vector, split_vector, Field126};
+    use crate::field::{random_vector, split_vector, Field128};
     use crate::pcp::gadgets::{Mul, PolyEval};
     use crate::polynomial::poly_range_check;
 
@@ -677,11 +677,11 @@ mod tests {
     fn test_pcp() {
         const NUM_SHARES: usize = 2;
 
-        let typ: TestType<Field126> = TestType::new();
+        let typ: TestType<Field128> = TestType::new();
         let input = typ.encode(&3).unwrap();
         assert_eq!(input.len(), typ.input_len());
 
-        let input_shares: Vec<Vec<Field126>> = split_vector(input.as_slice(), NUM_SHARES)
+        let input_shares: Vec<Vec<Field128>> = split_vector(input.as_slice(), NUM_SHARES)
             .unwrap()
             .into_iter()
             .collect();
@@ -693,12 +693,12 @@ mod tests {
         let proof = typ.prove(&input, &prove_rand, &joint_rand).unwrap();
         assert_eq!(proof.len(), typ.proof_len());
 
-        let proof_shares: Vec<Vec<Field126>> = split_vector(&proof, NUM_SHARES)
+        let proof_shares: Vec<Vec<Field128>> = split_vector(&proof, NUM_SHARES)
             .unwrap()
             .into_iter()
             .collect();
 
-        let verifier: Vec<Field126> = (0..NUM_SHARES)
+        let verifier: Vec<Field128> = (0..NUM_SHARES)
             .map(|i| {
                 typ.query(
                     &input_shares[i],

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -614,7 +614,7 @@ impl<I: Idpf<2, 2>> Collector for Poplar1<I> {
 mod tests {
     use super::*;
 
-    use crate::field::Field126;
+    use crate::field::Field128;
 
     #[test]
     fn test_ipdf() {
@@ -649,9 +649,9 @@ mod tests {
 
         // Generate IPDF keys.
         let input = IdpfInput::new(b"hi", 16).unwrap();
-        let keys = ToyIdpf::<Field126>::gen(
+        let keys = ToyIdpf::<Field128>::gen(
             &input,
-            std::iter::repeat([Field126::one(), Field126::one()]),
+            std::iter::repeat([Field128::one(), Field128::one()]),
         )
         .unwrap();
 
@@ -660,7 +660,7 @@ mod tests {
             let res = eval_idpf(
                 &keys,
                 &input.prefix(prefix_len),
-                &[Field126::one(), Field126::one()],
+                &[Field128::one(), Field128::one()],
             );
             assert!(res.is_ok(), "prefix_len={} error: {:?}", prefix_len, res);
         }
@@ -669,14 +669,14 @@ mod tests {
         eval_idpf(
             &keys,
             &IdpfInput::new(&[2], 2).unwrap(),
-            &[Field126::zero(), Field126::zero()],
+            &[Field128::zero(), Field128::zero()],
         )
         .unwrap();
 
         eval_idpf(
             &keys,
             &IdpfInput::new(&[23, 1], 12).unwrap(),
-            &[Field126::zero(), Field126::zero()],
+            &[Field128::zero(), Field128::zero()],
         )
         .unwrap();
     }
@@ -709,7 +709,7 @@ mod tests {
 
     #[test]
     fn test_poplar1() {
-        let vdaf: Poplar1<ToyIdpf<Field126>> = Poplar1::new(Suite::Blake3);
+        let vdaf: Poplar1<ToyIdpf<Field128>> = Poplar1::new(Suite::Blake3);
         assert_eq!(vdaf.num_aggregators(), 2);
 
         let (public_param, verify_params) = vdaf.setup().unwrap();
@@ -789,7 +789,7 @@ mod tests {
         let mut input_shares = vdaf.shard(&public_param, &input).unwrap();
         for (i, x) in input_shares[0].idpf.data0.iter_mut().enumerate() {
             if i != input.index {
-                *x += Field126::one();
+                *x += Field128::one();
             }
         }
         let mut agg_param = BTreeSet::new();
@@ -807,7 +807,7 @@ mod tests {
         // This IDPF key pair has a garbled authentication vector.
         let mut input_shares = vdaf.shard(&public_param, &input).unwrap();
         for x in input_shares[0].idpf.data1.iter_mut() {
-            *x = Field126::zero();
+            *x = Field128::zero();
         }
         let mut agg_param = BTreeSet::new();
         agg_param.insert(IdpfInput::new(b"xx", 16).unwrap());


### PR DESCRIPTION
Previous code considers only primes of at most 126 bits. Now, it adds support for 128-bit primes.

cc: @cjpatton 