### PR TITLE
Introduce trait `PrepareStep`

### DIFF
--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -97,6 +97,14 @@ impl<F: FieldElement> Encode for Share<F> {
     }
 }
 
+/// PrepareStep is the state associated with the multi-round VDAF input preparation process.
+pub trait PrepareStep {
+    /// Returns true if the prepare process is on the last round, meaning clients should call
+    /// [`Vdaf::prepare_finish`] to recover an output share, or false otherwise, in which case
+    /// clients should call [`Vdaf::prepare_next`] to get the next prepare message share.
+    fn is_last_round(&self) -> bool;
+}
+
 /// The base trait for VDAF schemes. This trait is inherited by traits [`Client`], [`Aggregator`],
 /// and [`Collector`], which define the roles of the various parties involved in the execution of
 /// the VDAF.
@@ -148,7 +156,7 @@ pub trait Client: Vdaf {
 /// The Aggregator's role in the execution of a VDAF.
 pub trait Aggregator: Vdaf {
     /// State of the Aggregator during the Prepare process.
-    type PrepareStep: Clone + Debug;
+    type PrepareStep: Clone + Debug + PrepareStep;
 
     /// The type of messages exchanged among the Aggregators during the Prepare process.
     type PrepareMessage: Clone + Debug + Decode<Self::PrepareStep> + Encode;

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -34,8 +34,8 @@ use crate::fp::log2;
 use crate::prng::Prng;
 use crate::vdaf::suite::{Key, KeyDeriver, KeyStream, Suite};
 use crate::vdaf::{
-    Aggregatable, AggregateShare, Aggregator, Client, Collector, OutputShare, PrepareTransition,
-    Share, ShareDecodingParameter, Vdaf, VdafError,
+    Aggregatable, AggregateShare, Aggregator, Client, Collector, OutputShare, PrepareStep,
+    PrepareTransition, Share, ShareDecodingParameter, Vdaf, VdafError,
 };
 
 /// An input for an IDPF ([`Idpf`]).
@@ -698,6 +698,12 @@ enum SketchState {
     Ready,
     RoundOne,
     RoundTwo,
+}
+
+impl<F> PrepareStep for Poplar1PrepareStep<F> {
+    fn is_last_round(&self) -> bool {
+        matches!(self.sketch, SketchState::RoundTwo)
+    }
 }
 
 impl<I: Idpf<2, 2>> Collector for Poplar1<I> {

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -19,8 +19,8 @@ use crate::pcp::Type;
 use crate::prng::Prng;
 use crate::vdaf::suite::{Key, KeyDeriver, KeyStream, Suite};
 use crate::vdaf::{
-    Aggregatable, AggregateShare, Aggregator, Client, Collector, OutputShare, PrepareTransition,
-    Share, ShareDecodingParameter, Vdaf, VdafError,
+    Aggregatable, AggregateShare, Aggregator, Client, Collector, OutputShare, PrepareStep,
+    PrepareTransition, Share, ShareDecodingParameter, Vdaf, VdafError,
 };
 use std::convert::{TryFrom, TryInto};
 use std::fmt::Debug;
@@ -501,6 +501,12 @@ impl<F> Prio3PrepareStep<F> {
                 joint_rand_seed, ..
             } => joint_rand_seed.suite(),
         }
+    }
+}
+
+impl<F> PrepareStep for Prio3PrepareStep<F> {
+    fn is_last_round(&self) -> bool {
+        matches!(self, Self::Waiting { .. })
     }
 }
 


### PR DESCRIPTION
Adds a trait bound on the `vdaf::PrepareStep` associated type. This
allows clients of `prio` to generically determine whether they should
expect the next state transition to be terminal, and thus whether they
should call `prepare_next` or `prepare_finish`. We then implement trait
`PrepareStep` on `Prio3PrepareStep` and `Poplar1PrepareStep`.