### PR TITLE
prio3: Align joint rand seed generation with spec

### DIFF
--- a/benches/speed_tests.rs
+++ b/benches/speed_tests.rs
@@ -4,6 +4,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 
 use prio::benchmarked::*;
 use prio::client::Client as Prio2Client;
+use prio::codec::Encode;
 use prio::encrypt::PublicKey;
 use prio::field::{random_vector, Field128 as F, FieldElement};
 use prio::pcp::gadgets::Mul;
@@ -13,7 +14,7 @@ use prio::vdaf::prio3::Prio3CountVec64Multithreaded;
 use prio::vdaf::{
     prio3::{Prio3Count64, Prio3CountVec64, Prio3Histogram64, Prio3InputShare, Prio3Sum64},
     suite::Suite,
-    Client as Prio3Client, Share,
+    Client as Prio3Client,
 };
 
 /// This benchmark compares the performance of recursive and iterative FFT.
@@ -204,26 +205,7 @@ pub fn prio3_client(c: &mut Criterion) {
 fn prio3_input_share_size<F: FieldElement>(input_shares: &[Prio3InputShare<F>]) -> usize {
     let mut size = 0;
     for input_share in input_shares {
-        match input_share.input_share {
-            Share::Leader(ref data) => {
-                size += data.len() * F::ENCODED_SIZE;
-            }
-            Share::Helper(ref seed) => {
-                size += seed.size();
-            }
-        };
-
-        match input_share.proof_share {
-            Share::Leader(ref data) => {
-                size += data.len() * F::ENCODED_SIZE;
-            }
-            Share::Helper(ref seed) => {
-                size += seed.size();
-            }
-        }
-
-        size += input_share.joint_rand_seed_hint.size();
-        size += input_share.blind.size();
+        size += input_share.get_encoded().len();
     }
 
     size

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -212,6 +212,7 @@ impl<T: Type, A: Clone + Debug + Sync + Send> Vdaf for Prio3<T, A> {
                     aggregator_id,
                     input_len: self.typ.input_len(),
                     proof_len: self.typ.proof_len(),
+                    joint_rand_len: self.typ.joint_rand_len(),
                 })
                 .collect(),
         ))
@@ -236,6 +237,9 @@ pub struct Prio3VerifyParam {
 
     /// Length in field elements of an uncompressed proof.
     proof_len: usize,
+
+    /// Length of the joint randomness.
+    joint_rand_len: usize,
 }
 
 /// The message sent by the client to each aggregator. This includes the client's input share and
@@ -249,13 +253,10 @@ pub struct Prio3InputShare<F> {
     pub proof_share: Share<F>,
 
     /// The sum of the joint randomness seed shares sent to the other aggregators.
-    //
-    // TODO(cjpatton) If `input.joint_rand_len() == 0`, then we don't need to bother with the joint
-    // randomness seed at all. See https://github.com/cjpatton/vdaf/issues/15.
-    pub joint_rand_seed_hint: Key,
+    pub joint_rand_seed_hint: Option<Key>,
 
     /// The blinding factor, used to derive the aggregator's joint randomness seed share.
-    pub blind: Key,
+    pub blind: Option<Key>,
 }
 
 impl<F: FieldElement> Encode for Prio3InputShare<F> {
@@ -269,8 +270,12 @@ impl<F: FieldElement> Encode for Prio3InputShare<F> {
 
         self.input_share.encode(bytes);
         self.proof_share.encode(bytes);
-        self.joint_rand_seed_hint.encode(bytes);
-        self.blind.encode(bytes);
+        if let Some(ref seed) = self.joint_rand_seed_hint {
+            seed.encode(bytes);
+        }
+        if let Some(ref seed) = self.blind {
+            seed.encode(bytes);
+        }
     }
 }
 
@@ -295,8 +300,14 @@ impl<F: FieldElement> Decode<Prio3VerifyParam> for Prio3InputShare<F> {
 
         let input_share = Share::decode(&input_decoding_parameter, bytes)?;
         let proof_share = Share::decode(&proof_decoding_parameter, bytes)?;
-        let joint_rand_seed_hint = Key::decode(&suite, bytes)?;
-        let blind = Key::decode(&suite, bytes)?;
+        let (joint_rand_seed_hint, blind) = if decoding_parameter.joint_rand_len > 0 {
+            (
+                Some(Key::decode(&suite, bytes)?),
+                Some(Key::decode(&suite, bytes)?),
+            )
+        } else {
+            (None, None)
+        };
 
         Ok(Prio3InputShare {
             input_share,
@@ -314,10 +325,7 @@ pub struct Prio3PrepareMessage<F> {
     pub verifier: Vec<F>,
 
     /// (A share of) the joint randomness seed.
-    //
-    // TODO(cjpatton) If `input.joint_rand_len() == 0`, then we don't need to bother with the joint
-    // randomness seed at all. See https://github.com/cjpatton/vdaf/issues/15.
-    pub joint_rand_seed: Key,
+    pub joint_rand_seed: Option<Key>,
 }
 
 impl<F: FieldElement> Encode for Prio3PrepareMessage<F> {
@@ -325,7 +333,9 @@ impl<F: FieldElement> Encode for Prio3PrepareMessage<F> {
         for x in &self.verifier {
             x.encode(bytes);
         }
-        self.joint_rand_seed.encode(bytes);
+        if let Some(ref seed) = self.joint_rand_seed {
+            seed.encode(bytes);
+        }
     }
 }
 
@@ -340,7 +350,11 @@ impl<F: FieldElement> Decode<Prio3PrepareStep<F>> for Prio3PrepareMessage<F> {
             verifier.push(F::decode(&(), bytes)?);
         }
 
-        let joint_rand_seed = Key::decode(&decoding_parameter.suite(), bytes)?;
+        let joint_rand_seed = if let Some(suite) = decoding_parameter.suite() {
+            Some(Key::decode(&suite, bytes)?)
+        } else {
+            None
+        };
 
         Ok(Prio3PrepareMessage {
             verifier,
@@ -444,6 +458,12 @@ impl<T: Type, A: Clone + Debug + Sync + Send> Client for Prio3<T, A> {
             *x ^= y;
         }
 
+        let (leader_joint_rand_seed_hint, leader_blind) = if self.typ.joint_rand_len() > 0 {
+            (Some(leader_joint_rand_seed_hint), Some(leader_blind))
+        } else {
+            (None, None)
+        };
+
         // Prep the output messages.
         let mut out = Vec::with_capacity(num_aggregators as usize);
         out.push(Prio3InputShare {
@@ -454,11 +474,17 @@ impl<T: Type, A: Clone + Debug + Sync + Send> Client for Prio3<T, A> {
         });
 
         for helper in helper_shares.into_iter() {
+            let (helper_joint_rand_seed_hint, helper_blind) = if self.typ.joint_rand_len() > 0 {
+                (Some(helper.joint_rand_seed_hint), Some(helper.blind))
+            } else {
+                (None, None)
+            };
+
             out.push(Prio3InputShare {
                 input_share: Share::Helper(helper.input_share),
                 proof_share: Share::Helper(helper.proof_share),
-                joint_rand_seed_hint: helper.joint_rand_seed_hint,
-                blind: helper.blind,
+                joint_rand_seed_hint: helper_joint_rand_seed_hint,
+                blind: helper_blind,
             });
         }
 
@@ -473,13 +499,13 @@ pub enum Prio3PrepareStep<F> {
     /// Ready to send the verifier message.
     Ready {
         input_share: Share<F>,
-        joint_rand_seed: Key,
+        joint_rand_seed: Option<Key>,
         verifier_msg: Prio3PrepareMessage<F>,
     },
     /// Waiting for the set of verifier messages.
     Waiting {
         input_share: Share<F>,
-        joint_rand_seed: Key,
+        joint_rand_seed: Option<Key>,
         verifier_len: usize,
     },
 }
@@ -492,15 +518,17 @@ impl<F> Prio3PrepareStep<F> {
         }
     }
 
-    fn suite(&self) -> Suite {
-        match self {
+    fn suite(&self) -> Option<Suite> {
+        let joint_rand_seed = match self {
             Self::Ready {
                 joint_rand_seed, ..
-            } => joint_rand_seed.suite(),
+            } => joint_rand_seed,
             Self::Waiting {
                 joint_rand_seed, ..
-            } => joint_rand_seed.suite(),
-        }
+            } => joint_rand_seed,
+        };
+
+        joint_rand_seed.as_ref().map(|seed| seed.suite())
     }
 }
 
@@ -551,20 +579,30 @@ impl<T: Type, A: Clone + Debug + Sync + Send> Aggregator for Prio3<T, A> {
         };
 
         // Compute the joint randomness.
-        let mut deriver = KeyDeriver::from_key(&msg.blind);
-        deriver.update(&[verify_param.aggregator_id]);
-        for x in input_share {
-            deriver.update(&(*x).into());
-        }
-        let joint_rand_seed_share = deriver.finish();
+        let (joint_rand_seed, joint_rand_seed_share, joint_rand) = if self.typ.joint_rand_len() > 0
+        {
+            let mut deriver = KeyDeriver::from_key(msg.blind.as_ref().unwrap());
+            deriver.update(&[verify_param.aggregator_id]);
+            for x in input_share {
+                deriver.update(&(*x).into());
+            }
+            let joint_rand_seed_share = deriver.finish();
 
-        let mut joint_rand_seed = Key::uninitialized(query_rand_seed.suite());
-        for (j, x) in joint_rand_seed.as_mut_slice().iter_mut().enumerate() {
-            *x = msg.joint_rand_seed_hint.as_slice()[j] ^ joint_rand_seed_share.as_slice()[j];
-        }
+            let mut joint_rand_seed = Key::uninitialized(query_rand_seed.suite());
+            for (j, x) in joint_rand_seed.as_mut_slice().iter_mut().enumerate() {
+                *x = msg.joint_rand_seed_hint.as_ref().unwrap().as_slice()[j]
+                    ^ joint_rand_seed_share.as_slice()[j];
+            }
 
-        let prng: Prng<T::Field> = Prng::from_key_stream(KeyStream::from_key(&joint_rand_seed));
-        let joint_rand: Vec<T::Field> = prng.take(self.typ.joint_rand_len()).collect();
+            let prng: Prng<T::Field> = Prng::from_key_stream(KeyStream::from_key(&joint_rand_seed));
+            (
+                Some(joint_rand_seed),
+                Some(joint_rand_seed_share),
+                prng.take(self.typ.joint_rand_len()).collect(),
+            )
+        } else {
+            (None, None, Vec::new())
+        };
 
         // Compute the query randomness.
         let prng: Prng<T::Field> = Prng::from_key_stream(KeyStream::from_key(&query_rand_seed));
@@ -607,24 +645,27 @@ impl<T: Type, A: Clone + Debug + Sync + Send> Aggregator for Prio3<T, A> {
                 )));
             }
 
-            if share.joint_rand_seed.suite() != self.suite {
-                return Err(VdafError::Uncategorized(format!(
-                    "unexpected suite for joint randomness seed share: got {:?}; want {:?}",
-                    share.joint_rand_seed.suite(),
-                    self.suite,
-                )));
+            if self.typ.joint_rand_len() > 0 {
+                let joint_rand_seed_share = share.joint_rand_seed.unwrap();
+                if joint_rand_seed_share.suite() != self.suite {
+                    return Err(VdafError::Uncategorized(format!(
+                        "unexpected suite for joint randomness seed share: got {:?}; want {:?}",
+                        joint_rand_seed_share.suite(),
+                        self.suite,
+                    )));
+                }
+
+                for (x, y) in joint_rand_seed
+                    .as_mut_slice()
+                    .iter_mut()
+                    .zip(joint_rand_seed_share.as_slice())
+                {
+                    *x ^= y;
+                }
             }
 
             for (x, y) in verifier.iter_mut().zip(share.verifier) {
                 *x += y;
-            }
-
-            for (x, y) in joint_rand_seed
-                .as_mut_slice()
-                .iter_mut()
-                .zip(share.joint_rand_seed.as_slice())
-            {
-                *x ^= y;
             }
         }
 
@@ -634,6 +675,12 @@ impl<T: Type, A: Clone + Debug + Sync + Send> Aggregator for Prio3<T, A> {
                 count, self.num_aggregators,
             )));
         }
+
+        let joint_rand_seed = if self.typ.joint_rand_len() > 0 {
+            Some(joint_rand_seed)
+        } else {
+            None
+        };
 
         Ok(Prio3PrepareMessage {
             verifier,
@@ -677,11 +724,13 @@ impl<T: Type, A: Clone + Debug + Sync + Send> Aggregator for Prio3<T, A> {
                 },
                 Some(msg),
             ) => {
-                // Check that the joint randomness was correct.
-                if joint_rand_seed != msg.joint_rand_seed {
-                    return PrepareTransition::Fail(VdafError::Uncategorized(
-                        "joint randomness mismatch".to_string(),
-                    ));
+                if self.typ.joint_rand_len() > 0 {
+                    // Check that the joint randomness was correct.
+                    if joint_rand_seed.as_ref().unwrap() != msg.joint_rand_seed.as_ref().unwrap() {
+                        return PrepareTransition::Fail(VdafError::Uncategorized(
+                            "joint randomness mismatch".to_string(),
+                        ));
+                    }
                 }
 
                 // Check the proof.
@@ -814,12 +863,16 @@ mod tests {
         let nonce = b"This is a good nonce.";
 
         let mut input_shares = prio3.shard(&(), &1).unwrap();
-        input_shares[0].blind.as_mut_slice()[0] ^= 255;
+        input_shares[0].blind.as_mut().unwrap().as_mut_slice()[0] ^= 255;
         let result = run_vdaf_prepare(&prio3, &verify_params, &(), nonce, input_shares);
         assert_matches!(result, Err(VdafError::Uncategorized(_)));
 
         let mut input_shares = prio3.shard(&(), &1).unwrap();
-        input_shares[0].joint_rand_seed_hint.as_mut_slice()[0] ^= 255;
+        input_shares[0]
+            .joint_rand_seed_hint
+            .as_mut()
+            .unwrap()
+            .as_mut_slice()[0] ^= 255;
         let result = run_vdaf_prepare(&prio3, &verify_params, &(), nonce, input_shares);
         assert_matches!(result, Err(VdafError::Uncategorized(_)));
 
@@ -880,7 +933,7 @@ mod tests {
 
     #[test]
     fn test_prio3_input_share() {
-        let prio3 = Prio3Count64::new(Suite::Blake3, 5).unwrap();
+        let prio3 = Prio3Sum64::new(Suite::Blake3, 5, 16).unwrap();
         let input_shares = prio3.shard(&(), &1).unwrap();
 
         // Check that seed shares are distinct.

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -247,16 +247,14 @@ pub struct Prio3VerifyParam {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Prio3InputShare<F> {
     /// The input share.
-    pub input_share: Share<F>,
+    input_share: Share<F>,
 
     /// The proof share.
-    pub proof_share: Share<F>,
+    proof_share: Share<F>,
 
-    /// The sum of the joint randomness seed shares sent to the other aggregators.
-    pub joint_rand_seed_hint: Option<Key>,
-
-    /// The blinding factor, used to derive the aggregator's joint randomness seed share.
-    pub blind: Option<Key>,
+    /// Parameters used by the Aggregator to compute the joint randomness. This field is optional
+    /// because not every [`pcp::Type`] requires joint randomness.
+    joint_rand_param: Option<JointRandParam>,
 }
 
 impl<F: FieldElement> Encode for Prio3InputShare<F> {
@@ -270,11 +268,9 @@ impl<F: FieldElement> Encode for Prio3InputShare<F> {
 
         self.input_share.encode(bytes);
         self.proof_share.encode(bytes);
-        if let Some(ref seed) = self.joint_rand_seed_hint {
-            seed.encode(bytes);
-        }
-        if let Some(ref seed) = self.blind {
-            seed.encode(bytes);
+        if let Some(ref param) = self.joint_rand_param {
+            param.seed_hint.encode(bytes);
+            param.blind.encode(bytes);
         }
     }
 }
@@ -300,20 +296,19 @@ impl<F: FieldElement> Decode<Prio3VerifyParam> for Prio3InputShare<F> {
 
         let input_share = Share::decode(&input_decoding_parameter, bytes)?;
         let proof_share = Share::decode(&proof_decoding_parameter, bytes)?;
-        let (joint_rand_seed_hint, blind) = if decoding_parameter.joint_rand_len > 0 {
-            (
-                Some(Key::decode(&suite, bytes)?),
-                Some(Key::decode(&suite, bytes)?),
-            )
+        let joint_rand_param = if decoding_parameter.joint_rand_len > 0 {
+            Some(JointRandParam {
+                seed_hint: Key::decode(&suite, bytes)?,
+                blind: Key::decode(&suite, bytes)?,
+            })
         } else {
-            (None, None)
+            None
         };
 
         Ok(Prio3InputShare {
             input_share,
             proof_share,
-            joint_rand_seed_hint,
-            blind,
+            joint_rand_param,
         })
     }
 }
@@ -379,7 +374,7 @@ impl<T: Type, A: Clone + Debug + Sync + Send> Client for Prio3<T, A> {
         for aggregator_id in 1..num_aggregators {
             let mut helper = HelperShare::new(self.suite)?;
 
-            let mut deriver = KeyDeriver::from_key(&helper.blind);
+            let mut deriver = KeyDeriver::from_key(&helper.joint_rand_param.blind);
             deriver.update(&[aggregator_id]);
             let prng: Prng<T::Field> =
                 Prng::from_key_stream(KeyStream::from_key(&helper.input_share));
@@ -392,11 +387,11 @@ impl<T: Type, A: Clone + Debug + Sync + Send> Client for Prio3<T, A> {
                 deriver.update(&y.into());
             }
 
-            helper.joint_rand_seed_hint = deriver.finish();
+            helper.joint_rand_param.seed_hint = deriver.finish();
             for (x, y) in joint_rand_seed
                 .as_mut_slice()
                 .iter_mut()
-                .zip(helper.joint_rand_seed_hint.as_slice().iter())
+                .zip(helper.joint_rand_param.seed_hint.as_slice().iter())
             {
                 *x ^= y;
             }
@@ -441,7 +436,8 @@ impl<T: Type, A: Clone + Debug + Sync + Send> Client for Prio3<T, A> {
             }
 
             for (x, y) in helper
-                .joint_rand_seed_hint
+                .joint_rand_param
+                .seed_hint
                 .as_mut_slice()
                 .iter_mut()
                 .zip(joint_rand_seed.as_slice().iter())
@@ -458,10 +454,13 @@ impl<T: Type, A: Clone + Debug + Sync + Send> Client for Prio3<T, A> {
             *x ^= y;
         }
 
-        let (leader_joint_rand_seed_hint, leader_blind) = if self.typ.joint_rand_len() > 0 {
-            (Some(leader_joint_rand_seed_hint), Some(leader_blind))
+        let leader_joint_rand_param = if self.typ.joint_rand_len() > 0 {
+            Some(JointRandParam {
+                seed_hint: leader_joint_rand_seed_hint,
+                blind: leader_blind,
+            })
         } else {
-            (None, None)
+            None
         };
 
         // Prep the output messages.
@@ -469,22 +468,20 @@ impl<T: Type, A: Clone + Debug + Sync + Send> Client for Prio3<T, A> {
         out.push(Prio3InputShare {
             input_share: Share::Leader(leader_input_share),
             proof_share: Share::Leader(leader_proof_share),
-            joint_rand_seed_hint: leader_joint_rand_seed_hint,
-            blind: leader_blind,
+            joint_rand_param: leader_joint_rand_param,
         });
 
         for helper in helper_shares.into_iter() {
-            let (helper_joint_rand_seed_hint, helper_blind) = if self.typ.joint_rand_len() > 0 {
-                (Some(helper.joint_rand_seed_hint), Some(helper.blind))
+            let helper_joint_rand_param = if self.typ.joint_rand_len() > 0 {
+                Some(helper.joint_rand_param)
             } else {
-                (None, None)
+                None
             };
 
             out.push(Prio3InputShare {
                 input_share: Share::Helper(helper.input_share),
                 proof_share: Share::Helper(helper.proof_share),
-                joint_rand_seed_hint: helper_joint_rand_seed_hint,
-                blind: helper_blind,
+                joint_rand_param: helper_joint_rand_param,
             });
         }
 
@@ -581,7 +578,7 @@ impl<T: Type, A: Clone + Debug + Sync + Send> Aggregator for Prio3<T, A> {
         // Compute the joint randomness.
         let (joint_rand_seed, joint_rand_seed_share, joint_rand) = if self.typ.joint_rand_len() > 0
         {
-            let mut deriver = KeyDeriver::from_key(msg.blind.as_ref().unwrap());
+            let mut deriver = KeyDeriver::from_key(&msg.joint_rand_param.as_ref().unwrap().blind);
             deriver.update(&[verify_param.aggregator_id]);
             for x in input_share {
                 deriver.update(&(*x).into());
@@ -590,7 +587,7 @@ impl<T: Type, A: Clone + Debug + Sync + Send> Aggregator for Prio3<T, A> {
 
             let mut joint_rand_seed = Key::uninitialized(query_rand_seed.suite());
             for (j, x) in joint_rand_seed.as_mut_slice().iter_mut().enumerate() {
-                *x = msg.joint_rand_seed_hint.as_ref().unwrap().as_slice()[j]
+                *x = msg.joint_rand_param.as_ref().unwrap().seed_hint.as_slice()[j]
                     ^ joint_rand_seed_share.as_slice()[j];
             }
 
@@ -806,12 +803,20 @@ where
     }
 }
 
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct JointRandParam {
+    /// The sum of the joint randomness seed shares sent to the other Aggregators.
+    seed_hint: Key,
+
+    /// The blinding factor, used to derive the aggregator's joint randomness seed share.
+    blind: Key,
+}
+
 #[derive(Clone)]
 struct HelperShare {
     input_share: Key,
     proof_share: Key,
-    joint_rand_seed_hint: Key,
-    blind: Key,
+    joint_rand_param: JointRandParam,
 }
 
 impl HelperShare {
@@ -819,8 +824,10 @@ impl HelperShare {
         Ok(HelperShare {
             input_share: Key::generate(suite)?,
             proof_share: Key::generate(suite)?,
-            joint_rand_seed_hint: Key::uninitialized(suite),
-            blind: Key::generate(suite)?,
+            joint_rand_param: JointRandParam {
+                seed_hint: Key::uninitialized(suite),
+                blind: Key::generate(suite)?,
+            },
         })
     }
 }
@@ -863,15 +870,21 @@ mod tests {
         let nonce = b"This is a good nonce.";
 
         let mut input_shares = prio3.shard(&(), &1).unwrap();
-        input_shares[0].blind.as_mut().unwrap().as_mut_slice()[0] ^= 255;
+        input_shares[0]
+            .joint_rand_param
+            .as_mut()
+            .unwrap()
+            .blind
+            .as_mut_slice()[0] ^= 255;
         let result = run_vdaf_prepare(&prio3, &verify_params, &(), nonce, input_shares);
         assert_matches!(result, Err(VdafError::Uncategorized(_)));
 
         let mut input_shares = prio3.shard(&(), &1).unwrap();
         input_shares[0]
-            .joint_rand_seed_hint
+            .joint_rand_param
             .as_mut()
             .unwrap()
+            .seed_hint
             .as_mut_slice()[0] ^= 255;
         let result = run_vdaf_prepare(&prio3, &verify_params, &(), nonce, input_shares);
         assert_matches!(result, Err(VdafError::Uncategorized(_)));
@@ -952,8 +965,7 @@ mod tests {
                         assert_ne!(left, right);
                     }
 
-                    assert_ne!(x.joint_rand_seed_hint, y.joint_rand_seed_hint);
-                    assert_ne!(x.blind, y.blind);
+                    assert_ne!(x.joint_rand_param, y.joint_rand_param);
                 }
             }
         }


### PR DESCRIPTION
If no joint randomness is required for the underlying FLP, then the spec
requires the client to not append the joint randomness seed hint or the
blind to the input share message. (Similarly, the spec requires the
aggregator to not send its joint randomness seed share in its prepare
message,)