### PR TITLE
cleanup: type alias for getrandom/test vector use

### DIFF
--- a/src/vdaf/prg.rs
+++ b/src/vdaf/prg.rs
@@ -16,6 +16,11 @@ use std::{
     io::{Cursor, Read},
 };
 
+/// Function pointer to fill a buffer with random bytes. Under normal operation,
+/// `getrandom::getrandom()` will be used, but other implementations can be used to control
+/// randomness when generating or verifying test vectors.
+pub(crate) type RandSource = fn(&mut [u8]) -> Result<(), getrandom::Error>;
+
 /// Input of [`Prg`].
 #[derive(Clone, Debug, Eq)]
 pub struct Seed<const L: usize>(pub(crate) [u8; L]);
@@ -26,9 +31,7 @@ impl<const L: usize> Seed<L> {
         Self::from_rand_source(getrandom::getrandom)
     }
 
-    pub(crate) fn from_rand_source<R: Fn(&mut [u8]) -> Result<(), getrandom::Error>>(
-        rand_source: R,
-    ) -> Result<Self, getrandom::Error> {
+    pub(crate) fn from_rand_source(rand_source: RandSource) -> Result<Self, getrandom::Error> {
         let mut seed = [0; L];
         rand_source(&mut seed)?;
         Ok(Self(seed))

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -17,7 +17,7 @@ use crate::pcp::gadgets::{BlindPolyEval, ParallelSum, ParallelSumGadget};
 use crate::pcp::types::{Count, CountVec, Histogram, Sum};
 use crate::pcp::Type;
 use crate::prng::Prng;
-use crate::vdaf::prg::{Prg, PrgAes128, Seed};
+use crate::vdaf::prg::{Prg, PrgAes128, RandSource, Seed};
 use crate::vdaf::{
     Aggregatable, AggregateShare, Aggregator, Client, Collector, OutputShare, PrepareTransition,
     Share, ShareDecodingParameter, Vdaf, VdafError,
@@ -27,8 +27,6 @@ use std::fmt::Debug;
 use std::io::Cursor;
 use std::iter::IntoIterator;
 use std::marker::PhantomData;
-
-use super::prg::RandSource;
 
 // TODO Add test vectors and make sure they pass.
 

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -28,6 +28,8 @@ use std::io::Cursor;
 use std::iter::IntoIterator;
 use std::marker::PhantomData;
 
+use super::prg::RandSource;
+
 // TODO Add test vectors and make sure they pass.
 
 // Domain-separation tag used to bind the VDAF operations to the document version. This will be
@@ -224,9 +226,9 @@ where
         self.typ.verifier_len()
     }
 
-    fn setup_with_rand_source<R: Fn(&mut [u8]) -> Result<(), getrandom::Error>>(
+    fn setup_with_rand_source(
         &self,
-        rand_source: R,
+        rand_source: RandSource,
     ) -> Result<((), Vec<Prio3VerifyParam<L>>), VdafError> {
         let query_rand_init = Seed::from_rand_source(rand_source)?;
         Ok((
@@ -243,15 +245,12 @@ where
         ))
     }
 
-    fn shard_with_rand_source<R>(
+    fn shard_with_rand_source(
         &self,
         _public_param: &(),
         measurement: &T::Measurement,
-        rand_source: R,
-    ) -> Result<Vec<Prio3InputShare<T::Field, L>>, VdafError>
-    where
-        R: Fn(&mut [u8]) -> Result<(), getrandom::Error> + Copy,
-    {
+        rand_source: RandSource,
+    ) -> Result<Vec<Prio3InputShare<T::Field, L>>, VdafError> {
         let mut info = [0; VERS_PRIO3.len() + 1];
         info[..VERS_PRIO3.len()].clone_from_slice(VERS_PRIO3);
 
@@ -901,10 +900,7 @@ struct HelperShare<const L: usize> {
 }
 
 impl<const L: usize> HelperShare<L> {
-    fn from_rand_source<R>(rand_source: R) -> Result<Self, VdafError>
-    where
-        R: Fn(&mut [u8]) -> Result<(), getrandom::Error> + Copy,
-    {
+    fn from_rand_source(rand_source: RandSource) -> Result<Self, VdafError> {
         Ok(HelperShare {
             input_share: Seed::from_rand_source(rand_source)?,
             proof_share: Seed::from_rand_source(rand_source)?,


### PR DESCRIPTION
This replaces a few generic `Fn` type bounds with an alias to a function pointer, to clean up signatures that take a randomness source.