### PR TITLE
prio3: Encode prepare step in "waiting" state

### DIFF
--- a/src/vdaf.rs
+++ b/src/vdaf.rs
@@ -205,6 +205,7 @@ pub trait Collector: Vdaf {
 }
 
 /// A state transition of an Aggregator during the Prepare process.
+#[derive(Debug)]
 pub enum PrepareTransition<S, M, O> {
     /// Continue processing.
     Continue(S, M),


### PR DESCRIPTION
This functionality is useful for implementations of PPM that need to
offload the helper state to persistent storage while waiting for a reply
from the leader.