### PR TITLE
Documentation cleanup

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -53,8 +53,8 @@ pub trait ParameterizedDecode<P>: Sized {
         bytes: &mut Cursor<&[u8]>,
     ) -> Result<Self, CodecError>;
 
-    /// Convenience method to get decoded value. Returns an error if [`Self::decode`] fails, or if
-    /// there are any bytes left in `bytes` after decoding a value.
+    /// Convenience method to get decoded value. Returns an error if [`Self::decode_with_param`]
+    /// fails, or if there are any bytes left in `bytes` after decoding a value.
     fn get_decoded_with_param(decoding_parameter: &P, bytes: &[u8]) -> Result<Self, CodecError> {
         let mut cursor = Cursor::new(bytes);
         let decoded = Self::decode_with_param(decoding_parameter, &mut cursor)?;

--- a/src/field.rs
+++ b/src/field.rs
@@ -129,7 +129,7 @@ pub trait FieldElement:
     /// # Warnings
     ///
     /// This function should only be used within [`prng::Prng`] to convert a random byte string into
-    /// a field element. Use [`Self::try_from_reader`] to deserialize field elements. Use
+    /// a field element. Use [`Self::decode`] to deserialize field elements. Use
     /// [`field::rand`] or [`prng::Prng`] to randomly generate field elements.
     #[doc(hidden)]
     fn try_from_random(bytes: &[u8]) -> Result<Self, FieldError>;
@@ -172,7 +172,7 @@ pub trait FieldElement:
     ///
     /// Returns an error if the length of the provided byte slice is not a multiple of the size of a
     /// field element, or if any of the values in the byte slice are invalid encodings of a field
-    /// element as documented in [`Self::try_from_reader`].
+    /// element, because the encoded integer is larger than the field modulus.
     ///
     /// # Notes
     ///

--- a/src/field.rs
+++ b/src/field.rs
@@ -124,7 +124,7 @@ pub trait FieldElement:
     /// # Errors
     ///
     /// An error is returned if the provided slice is too small to encode a field element or if the
-    /// result encodes an integer larger than the field modulus.
+    /// result encodes an integer larger than or equal to the field modulus.
     ///
     /// # Warnings
     ///
@@ -172,7 +172,7 @@ pub trait FieldElement:
     ///
     /// Returns an error if the length of the provided byte slice is not a multiple of the size of a
     /// field element, or if any of the values in the byte slice are invalid encodings of a field
-    /// element, because the encoded integer is larger than the field modulus.
+    /// element, because the encoded integer is larger than or equal to the field modulus.
     ///
     /// # Notes
     ///

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -577,6 +577,11 @@ pub struct Prio3PrepareStep<F, const L: usize> {
 }
 
 impl<F: FieldElement, const L: usize> Encode for Prio3PrepareStep<F, L> {
+    /// Append the encoded form of this object to the end of `bytes`, growing the vector as needed.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the step is not in the "waiting" state. See [`Prio3PrepareStep`] for details.
     fn encode(&self, bytes: &mut Vec<u8>) {
         if let PrepareStep::Ready(..) = self.state {
             panic!("encooding of ready state is not permitted (see documentation for details)");


### PR DESCRIPTION
The first commit here adds documentation of panic behavior directly on `<Prio3PrepareStep as Encode>::encode()`, as a follow-up to #195. The second commit fixes some rustdoc warnings due to broken references.