### PR TITLE
Remove `rust-toolchain.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 description = "Implementation of the Prio aggregation system core: https://crypto.stanford.edu/prio/"
 license = "MPL-2.0"
 repository = "https://github.com/abetterinternet/libprio-rs"
+rust-version = "1.58"
 
 [dependencies]
 aes = "0.8.1"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "1.56.1"
-components = [ "rustc", "rustfmt", "clippy" ]

--- a/src/client.rs
+++ b/src/client.rs
@@ -118,17 +118,17 @@ impl<F: FieldElement> Client<F> {
     {
         let mut proof = vec![F::zero(); proof_length(self.dimension)];
         // unpack one long vector to different subparts
-        let mut unpacked = unpack_proof_mut(&mut proof, self.dimension).unwrap();
+        let unpacked = unpack_proof_mut(&mut proof, self.dimension).unwrap();
         // initialize the data part
-        init_function(&mut unpacked.data);
+        init_function(unpacked.data);
         // fill in the rest
         construct_proof(
             unpacked.data,
             self.dimension,
-            &mut unpacked.f0,
-            &mut unpacked.g0,
-            &mut unpacked.h0,
-            &mut unpacked.points_h_packed,
+            unpacked.f0,
+            unpacked.g0,
+            unpacked.h0,
+            unpacked.points_h_packed,
             self,
         );
 

--- a/src/fp.rs
+++ b/src/fp.rs
@@ -78,11 +78,6 @@ impl FieldParameters {
         let y = [lo64(y), hi64(y)];
         let p = [lo64(self.p), hi64(self.p)];
         let mut zz = [0; 4];
-        let mut result: u128;
-        let mut carry: u128;
-        let mut hi: u128;
-        let mut lo: u128;
-        let mut cc: u128;
 
         // Integer multiplication
         // z = x * y
@@ -91,15 +86,15 @@ impl FieldParameters {
         // *     y1,y0
         // ===========
         // z3,z2,z1,z0
-        result = x[0] * y[0];
-        carry = hi64(result);
+        let mut result = x[0] * y[0];
+        let mut carry = hi64(result);
         zz[0] = lo64(result);
         result = x[0] * y[1];
-        hi = hi64(result);
-        lo = lo64(result);
+        let mut hi = hi64(result);
+        let mut lo = lo64(result);
         result = lo + carry;
         zz[1] = lo64(result);
-        cc = hi64(result);
+        let mut cc = hi64(result);
         result = hi + cc;
         zz[2] = lo64(result);
 

--- a/src/polynomial.rs
+++ b/src/polynomial.rs
@@ -65,9 +65,9 @@ fn fft_recurse<F: FieldElement>(
 
     let half_n = n / 2;
 
-    let (mut tmp_first, mut tmp_second) = tmp.split_at_mut(half_n);
-    let (y_sub_first, mut y_sub_second) = y_sub.split_at_mut(half_n);
-    let (roots_sub_first, mut roots_sub_second) = roots_sub.split_at_mut(half_n);
+    let (tmp_first, tmp_second) = tmp.split_at_mut(half_n);
+    let (y_sub_first, y_sub_second) = y_sub.split_at_mut(half_n);
+    let (roots_sub_first, roots_sub_second) = roots_sub.split_at_mut(half_n);
 
     // Recurse on the first half
     for i in 0..half_n {
@@ -75,13 +75,13 @@ fn fft_recurse<F: FieldElement>(
         roots_sub_first[i] = roots[2 * i];
     }
     fft_recurse(
-        &mut tmp_first,
+        tmp_first,
         half_n,
         roots_sub_first,
         y_sub_first,
-        &mut tmp_second,
-        &mut y_sub_second,
-        &mut roots_sub_second,
+        tmp_second,
+        y_sub_second,
+        roots_sub_second,
     );
     for i in 0..half_n {
         out[2 * i] = tmp_first[i];
@@ -93,13 +93,13 @@ fn fft_recurse<F: FieldElement>(
         y_sub_first[i] *= roots[i];
     }
     fft_recurse(
-        &mut tmp_first,
+        tmp_first,
         half_n,
         roots_sub_first,
         y_sub_first,
-        &mut tmp_second,
-        &mut y_sub_second,
-        &mut roots_sub_second,
+        tmp_second,
+        y_sub_second,
+        roots_sub_second,
     );
     for i in 0..half_n {
         out[2 * i + 1] = tmp[i];

--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -18,7 +18,6 @@
 //! [BBCG+21]: https://eprint.iacr.org/2021/017
 //! [draft-patton-cfrg-vdaf-01]: https://datatracker.ietf.org/doc/html/draft-patton-cfrg-vdaf-01
 
-use std::array::IntoIter;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, BTreeSet};
 use std::convert::{TryFrom, TryInto};
@@ -409,16 +408,16 @@ where
         }
 
         // Generate IDPF shares of the data and authentication vectors.
-        let mut idpf_shares = IntoIter::new(I::gen(input, idpf_values)?);
+        let idpf_shares = I::gen(input, idpf_values)?;
 
         Ok(vec![
             Poplar1InputShare {
-                idpf: idpf_shares.next().unwrap(),
+                idpf: idpf_shares[0].clone(),
                 sketch_start_seed: leader_sketch_start_seed,
                 sketch_next: Share::Leader(leader_sketch_next),
             },
             Poplar1InputShare {
-                idpf: idpf_shares.next().unwrap(),
+                idpf: idpf_shares[1].clone(),
                 sketch_start_seed: helper_sketch_start_seed,
                 sketch_next: Share::Helper(helper_sketch_next_seed),
             },

--- a/src/vdaf/prio3_test.rs
+++ b/src/vdaf/prio3_test.rs
@@ -42,9 +42,10 @@ struct TPrio3<M> {
 macro_rules! err {
     (
         $test_num:ident,
+        $error:expr,
         $msg:expr
     ) => {
-        &format!("test #{} failed: {}", $test_num, $msg)
+        panic!("test #{} failed: {} err: {}", $test_num, $msg, $error)
     };
 }
 
@@ -70,7 +71,7 @@ fn check_prep_test_vec<M, T, A, P, const L: usize>(
         assert_eq!(
             input_shares[i],
             Prio3InputShare::get_decoded_with_param(&verify_params[i], want.as_ref())
-                .expect(err!(test_num, "decode test vector (input share)")),
+                .unwrap_or_else(|e| err!(test_num, e, "decode test vector (input share)")),
             "#{}",
             test_num
         );
@@ -86,7 +87,7 @@ fn check_prep_test_vec<M, T, A, P, const L: usize>(
     for (verify_param, input_share) in verify_params.iter().zip(input_shares) {
         let state = prio3
             .prepare_init(verify_param, &(), &t.nonce, &input_share)
-            .expect(err!(test_num, "prep state init"));
+            .unwrap_or_else(|e| err!(test_num, e, "prep state init"));
         states.push(state);
     }
 
@@ -106,7 +107,7 @@ fn check_prep_test_vec<M, T, A, P, const L: usize>(
         assert_eq!(
             prep_shares[i],
             Prio3PrepareMessage::get_decoded_with_param(&states[i], want.as_ref())
-                .expect(err!(test_num, "decode test vector (prep share)")),
+                .unwrap_or_else(|e| err!(test_num, e, "decode test vector (prep share)")),
             "#{}",
             test_num
         );
@@ -116,7 +117,7 @@ fn check_prep_test_vec<M, T, A, P, const L: usize>(
     let inbound = Some(
         prio3
             .prepare_preprocess(prep_shares)
-            .expect(err!(test_num, "prep preprocess")),
+            .unwrap_or_else(|e| err!(test_num, e, "prep preprocess")),
     );
 
     let mut out_shares = Vec::new();


### PR DESCRIPTION
My aim in introducing a `rust-toolchain.toml` was to ensure that all
builds of crate `prio` would use a consistent Rust toolchain. However
there's two problems with this. First, Rust projects that pull in crate
`prio` ignore its `rust-toolchain.yaml`. Second, dependabot doesn't know
about `rust-toolchain.yaml`, which means that our toolchain was falling
behind the latest releases from the Rust project. We now instead specify
a `rust-version` in `Cargo.toml`, which enforces a minimum toolchain
version for using `prio`. I specified 1.58 because that's what GitHub
Actions workers currently install.

This commit also fixes some warnings uncovered by building the crate
with a more recent toolchain (1.59 on my machine).