### PR TITLE
Opaque VDAF message structs

### DIFF
--- a/src/vdaf/poplar1.rs
+++ b/src/vdaf/poplar1.rs
@@ -259,14 +259,14 @@ impl Decode for BTreeSet<IdpfInput> {
 #[derive(Debug, Clone)]
 pub struct Poplar1InputShare<I: Idpf<2, 2>, const L: usize> {
     /// IDPF share of input
-    pub idpf: I,
+    idpf: I,
 
     /// PRNG seed used to generate the aggregator's share of the randomness used in the first part
     /// of the sketching protocol.
-    pub sketch_start_seed: Seed<L>,
+    sketch_start_seed: Seed<L>,
 
     /// Aggregator's share of the randomness used in the second part of the sketching protocol.
-    pub sketch_next: Share<I::Field, L>,
+    sketch_next: Share<I::Field, L>,
 }
 
 impl<I: Idpf<2, 2>, const L: usize> Encode for Poplar1InputShare<I, L> {

--- a/src/vdaf/prio3.rs
+++ b/src/vdaf/prio3.rs
@@ -410,10 +410,10 @@ where
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct Prio3VerifyParam<const L: usize> {
     /// Key used to derive the query randomness from the nonce.
-    pub query_rand_init: Seed<L>,
+    query_rand_init: Seed<L>,
 
     /// The identity of the aggregator.
-    pub aggregator_id: u8,
+    aggregator_id: u8,
 
     /// Length in field elements of an uncompressed input share.
     input_len: usize,
@@ -532,10 +532,10 @@ impl<F: FieldElement, const L: usize> ParameterizedDecode<Prio3VerifyParam<L>>
 /// The verification message emitted by each aggregator during the Prepare process.
 pub struct Prio3PrepareMessage<F, const L: usize> {
     /// (A share of) the FLP verifier message. (See [`Type`](crate::flp::Type).)
-    pub verifier: Vec<F>,
+    verifier: Vec<F>,
 
     /// (A share of) the joint randomness seed.
-    pub joint_rand_seed: Option<Seed<L>>,
+    joint_rand_seed: Option<Seed<L>>,
 }
 
 impl<F: FieldElement, const L: usize> Encode for Prio3PrepareMessage<F, L> {


### PR DESCRIPTION
Make all the fields on structs implementing VDAF messages private, to
reduce the risk of callers mutating state and invalidating security or
privacy properties.

Resolves #176